### PR TITLE
Refactor validation system to support `submissionOnly` and additional details

### DIFF
--- a/packages/form-engine/docs/block-type-documentation.md
+++ b/packages/form-engine/docs/block-type-documentation.md
@@ -2,8 +2,8 @@
 
 ## Overview
 
-The form system uses a hierarchical block architecture to create flexible, declarative forms. 
-All UI components are represented as 'blocks', with specialized types for different use cases. 
+The form system uses a hierarchical block architecture to create flexible, declarative forms.
+All UI components are represented as 'blocks', with specialized types for different use cases.
 This document explains the four main block types and how they work together.
 
 ### Block Type Hierarchy
@@ -17,7 +17,7 @@ Block (Base)
 
 ## 1. Block (Base Type)
 
-The foundational building block for all interface components. Blocks are pure UI 
+The foundational building block for all interface components. Blocks are pure UI
 configuration objects that represent visual elements without any kind of form input.
 
 ### Structure
@@ -42,7 +42,7 @@ const checkAnswersBeforeSendingExamplehHeadingBlock = block({
 // Expanding details block
 const nationalityExampleDetailsBlock = block({
   variant: 'details',
-  summaryText: 'Help with nationality'
+  summaryText: 'Help with nationality',
   text: `We need to know your nationality so we can work out which
         elections you’re entitled to vote in. If you cannot provide your
         nationality, you’ll have to send copies of identity documents through the post.`
@@ -53,7 +53,7 @@ const legalNotice = block({
   variant: 'html',
   content: `
     <div>
-      <p class='govuk-body'>By proceeding, you agree to our 
+      <p class='govuk-body'>By proceeding, you agree to our
          <a href="/terms">Terms of Service</a>
       </p>
     </div>
@@ -61,6 +61,7 @@ const legalNotice = block({
 })
 ```
 ### Concepts
+
 #### `block`
 All blocks are marked as `block` as their type. This is so they can easily be identified during JSON parsing.
 #### `variant`
@@ -69,7 +70,7 @@ that are registered into the BlocksRegistry, for UI rendering. Some examples are
 
 ## 2. Field
 
-Fields are specialized blocks that handle form inputs with data binding, 
+Fields are specialized blocks that handle form inputs with data binding,
 validation, and conditional display logic. They extend the base block functionality with form-specific capabilities.
 
 ### Structure
@@ -78,7 +79,7 @@ validation, and conditional display logic. They extend the base block functional
 interface FieldDefinition extends BlockDefinition {
   code: ConditionalString             // Data binding key
   value?: ConditionalString           // Default value
-  validate?: CompiledRule[]           // Validation rules
+  validate?: ValidationExpr[]         // Validation rules
   dependent?: CompiledRule            // Conditional display/validation rule
   // ... variant-specific properties
 }
@@ -87,7 +88,7 @@ interface FieldDefinition extends BlockDefinition {
 ### Examples
 ```typescript
 // A conditional text input field
-// This field has two validation rules; 
+// This field has two validation rules;
 // 1. If no value is entered, then validation error with "Enter which other drug they've misused"
 // 2. If value is over max length of 200 characters, then validation
 //    error with "Enter which other drug they've misused"
@@ -102,25 +103,30 @@ const otherDrugNameField: TextField = field({
     classes: GovUKClasses.visuallyHidden,
   },
   validate: [
-    when(Self().not.match(Condition.IsRequired()))
-      .then("Enter which other drug they've misused"),
-    when(Self().not.match(Condition.HasMaxLength(characterLimits.c200)))
-      .then(`Drug name must be ${characterLimits.c200} characters or less`,
-    ),
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: "Enter which other drug they've misused"
+    }),
+    validation({
+      when: Self().not.match(Condition.HasMaxLength(characterLimits.c200)),
+      message: `Drug name must be ${characterLimits.c200} characters or less`
+    }),
   ],
   dependent: when(Answer('select_misused_drugs').match(Condition.Contains('OTHER_DRUG'))),
 })
 
 // A radio input field that is always shown (no dependent)
-// This field has a single validation rule; 
+// This field has a single validation rule;
 // 1. If no value is entered, then validation error with "Select if they've ever misused drugs"
 const drugUse: RadioField = field({
   variant: 'radio',
   code: 'drug_use',
   hint: 'This includes illegal and prescription drugs.',
   validate: [
-    when(Self().not.match(Condition.IsRequired()))
-      .then("Select if they've ever misused drugs")
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: "Select if they've ever misused drugs"
+    })
   ],
   items: [
     { value: 'YES', label: 'Yes' },
@@ -129,23 +135,29 @@ const drugUse: RadioField = field({
 })
 ```
 ### Concepts
+
 #### `code`
-The unique identifier that determines where the field's value is stored and retrieved. When rendered as HTML, 
-the code becomes the field's name attribute, making it the key used to access the field's 
+The unique identifier that determines where the field's value is stored and retrieved. When rendered as HTML,
+the code becomes the field's name attribute, making it the key used to access the field's
 value in form submissions (POST data) and stored answers.
 
 #### `validate`
-Validation rules define conditions that determine when a field's value is invalid and should 
-display an error message to the user. Each rule consists of:
+Validation rules define conditions that determine when a field's value is invalid and should
+display an error message to the user. Each rule is a `ValidationExpr` with:
 
-1. A predicate expression that evaluates to true or false
-2. A corresponding error message to display when validation fails
+1. `when: PredicateExpr` - A predicate expression that when true triggers validation failure
+2. `message: string` - Error message to display when validation fails
+3. `submissionOnly?: boolean` - If true, only checked at submission time, not during journey traversal
 
-These rules typically use negative logic (with .not.match()) to check for invalid conditions 
+These rules typically use negative logic (with .not.match()) to check for invalid conditions
 rather than valid ones. This approach allows the system to identify and report specific validation failures.
 
+**Submission-Only Validations**: Some validations (like username uniqueness checks) are only valid
+at submission time and should not be re-checked during journey path traversal. Mark these with
+`submissionOnly: true`.
+
 #### `dependent`
-The dependent property determines whether a field should be included in form processing 
+The dependent property determines whether a field should be included in form processing
 based on conditional logic. It serves two critical functions:
 
 1. Validation Control: When a field's dependent condition evaluates to false,
@@ -156,7 +168,7 @@ Here's a section for CompositeBlock that follows the same style and structure:
 
 ## 3. CompositeBlock
 
-CompositeBlocks are containers that group other blocks together for structural organization and visual layout. 
+CompositeBlocks are containers that group other blocks together for structural organization and visual layout.
 They provide a way to create reusable form sections and organize related fields into logical groups.
 
 ### Structure
@@ -181,17 +193,21 @@ const personalDetailsFieldset = block({
       code: 'first_name',
       label: 'First Name',
       validate: [
-        when(Self().not.match(Condition.IsRequired()))
-          .then('First name is required')
+        validation({
+          when: Self().not.match(Condition.IsRequired()),
+          message: 'First name is required'
+        })
       ]
     }),
     field({
-      variant: 'text', 
+      variant: 'text',
       code: 'last_name',
       label: 'Last Name',
       validate: [
-        when(Self().not.match(Condition.IsRequired()))
-          .then('Last name is required')
+        validation({
+          when: Self().not.match(Condition.IsRequired()),
+          message: 'Last name is required'
+        })
       ]
     }),
     field({
@@ -199,10 +215,14 @@ const personalDetailsFieldset = block({
       code: 'email',
       label: 'Email Address',
       validate: [
-        when(Self().not.match(Condition.IsRequired()))
-          .then('Email is required'),
-        when(Self().not.match(Condition.IsEmail()))
-          .then('Enter a valid email address')
+        validation({
+          when: Self().not.match(Condition.IsRequired()),
+          message: 'Email is required'
+        }),
+        validation({
+          when: Self().not.match(Condition.IsEmail()),
+          message: 'Enter a valid email address'
+        })
       ]
     })
   ]
@@ -222,7 +242,7 @@ const billingAddressSection = block({
     }),
     field({
       variant: 'text',
-      code: 'billing_city', 
+      code: 'billing_city',
       label: 'City',
       dependent: when(Answer('same_as_delivery').not.match(Condition.MatchesValue(true))),
     }),
@@ -237,16 +257,17 @@ const billingAddressSection = block({
 ```
 
 ### Concepts
+
 #### `blocks`
-An array of child blocks (Fields, Blocks, or other CompositeBlocks) that are contained within this composite block. 
+An array of child blocks (Fields, Blocks, or other CompositeBlocks) that are contained within this composite block.
 These child blocks are rendered as a group together.
 
 Here's a section for CollectionBlock following the same style:
 
 ## 4. CollectionBlock
 
-CollectionBlocks iterate over arrays of data to generate repeated form sections dynamically. 
-They use templates that are instantiated for each item in a collection, allowing forms to 
+CollectionBlocks iterate over arrays of data to generate repeated form sections dynamically.
+They use templates that are instantiated for each item in a collection, allowing forms to
 handle variable amounts of data efficiently.
 
 ### Structure
@@ -277,8 +298,10 @@ const savedAddressesCollection = block({
       label: 'Street Address',
       value: Item('street'),  // Pre-populate from collection item
       validate: [
-        when(Self().not.match(Condition.IsRequired()))
-          .then('Street address is required')
+        validation({
+          when: Self().not.match(Condition.IsRequired()),
+          message: 'Street address is required'
+        })
       ]
     }),
     field({
@@ -313,8 +336,10 @@ const drugUsageCollection = block({
         { label: 'Used more than 6 months ago', value: 'MORE_THAN_SIX' }
       ],
       validate: [
-        when(Self().not.match(Condition.IsRequired()))
-          .then('Select when they last used this drug')
+        validation({
+          when: Self().not.match(Condition.IsRequired()),
+          message: 'Select when they last used this drug'
+        })
       ]
     }),
   ],
@@ -327,15 +352,16 @@ const drugUsageCollection = block({
 ### Concepts
 
 #### `template`
-An array of blocks that serve as the blueprint for each item in the collection. 
-The template is repeated once for every item, with `Item()` references resolved to the current item's data. 
+An array of blocks that serve as the blueprint for each item in the collection.
+The template is repeated once for every item, with `Item()` references resolved to the current item's data.
 Templates can contain any type of block: Fields, Blocks, or even nested CompositeBlocks.
 
 #### `collectionContext`
-Configuration that defines the data source and iteration behavior. The `collection` property 
+Configuration that defines the data source and iteration behavior. The `collection` property
 specifies which array to iterate over, while the optional `target` property can focus on a specific item or index within the collection.
 
 #### Dynamic Field Generation
+
 When using fields in CollectionBlocks, it's worth giving them unique `code` attributes by combining the
-`Format()` expression with an `Item()` reference. This ensures each repeated 
+`Format()` expression with an `Item()` reference. This ensures each repeated
 field has a distinct identifier while maintaining a predictable naming pattern.

--- a/packages/form-engine/docs/block-type-documentation.md
+++ b/packages/form-engine/docs/block-type-documentation.md
@@ -148,13 +148,11 @@ display an error message to the user. Each rule is a `ValidationExpr` with:
 1. `when: PredicateExpr` - A predicate expression that when true triggers validation failure
 2. `message: string` - Error message to display when validation fails
 3. `submissionOnly?: boolean` - If true, only checked at submission time, not during journey traversal
+4. `details?: Record<string, string>` - Details to include about the error, can be
+   used for highlighting severity or specific sub-field in a composite component that failed validation.
 
 These rules typically use negative logic (with .not.match()) to check for invalid conditions
 rather than valid ones. This approach allows the system to identify and report specific validation failures.
-
-**Submission-Only Validations**: Some validations (like username uniqueness checks) are only valid
-at submission time and should not be re-checked during journey path traversal. Mark these with
-`submissionOnly: true`.
 
 #### `dependent`
 The dependent property determines whether a field should be included in form processing

--- a/packages/form-engine/docs/custom-condition-functions.md
+++ b/packages/form-engine/docs/custom-condition-functions.md
@@ -293,8 +293,8 @@ validate: [
 
 // Compiles to JSON
 {
-  type: 'LogicType.Conditional',
-  predicate: {
+  type: 'validation',
+  when: {
     type: 'LogicType.Test',
     subject: { type: 'ExpressionType.Reference', path: ['@self'] },
     negate: false,

--- a/packages/form-engine/docs/custom-condition-functions.md
+++ b/packages/form-engine/docs/custom-condition-functions.md
@@ -70,8 +70,17 @@ types when the condition is used in your form configuration:
 ```typescript
 // TypeScript will enforce correct types
 validate: [
-  when(Self().match(hasMinValue(10))),        // ✓ Correct
-  when(Self().match(hasMinValue('10')))      // ✗ Type error
+  // BAD - Will have a type error
+  validation({
+    when: Self().match(hasMinValue('10')),
+    message: 'Invalid type'
+  }),
+
+  // GOOD - Uses correct type for condition arguments.
+  validation({
+    when: Self().match(hasMinValue(10)),
+    message: 'Value must be at least 10'
+  }),
 ]
 ```
 
@@ -136,15 +145,9 @@ const isStrongPassword = defineFunction(
 For conditions that need to perform asynchronous operations:
 
 > [!IMPORTANT]
-> If you do use an external data source for validation/conditional logic, expect that the data may change and then
-> cause a user to be reverted to an earlier step in the journey if it was used for validation (due to journey path
-> transversal checking). I would recommend against doing this.
-
->[!WARNING]
-> There's probably some kind of solution to the above warning where a function/validation operation can be marked
-> as non-pure so it's skipped for validation checking when doing journey path transversal checks. That would
-> allow for a nice mixture of at-submission validation, like the below example for unique usernames, as this would
-> cause a failure in subsequent validation check (as the username would now have been registered).
+> If you do use an external data source for validation/conditional logic, expect that the data may change.
+> Use `submissionOnly` for these validations to not trap the user to an earlier step in the form when they
+> next access previously submitted form data.
 
 ```typescript
 const isUniqueUsername = defineFunction(
@@ -264,8 +267,14 @@ const matchesLength = defineFunction(
 
 // Can be used in multiple ways
 validate: [
-  when(Self().not.match(matchesLength(5))).then('Minimum 5 characters'),
-  when(Self().not.match(matchesLength(5, 20))).then('Between 5-20 characters')
+  validation({
+    when: Self().not.match(matchesLength(5)),
+    message: 'Minimum 5 characters'
+  }),
+  validation({
+    when: Self().not.match(matchesLength(5, 20)),
+    message: 'Between 5-20 characters'
+  })
 ]
 ```
 
@@ -276,14 +285,16 @@ When custom functions are used in form configuration, they compile to the standa
 ```typescript
 // Usage in configuration
 validate: [
-  when(Self().match(isStrongPassword({ minLength: 12 })))
-    .then('Valid password')
+  validation({
+    when: Self().match(isStrongPassword({ minLength: 12 })),
+    message: 'Valid password'
+  })
 ]
 
 // Compiles to JSON
 {
-  type: 'conditional',
-  predicate: {
+  type: 'validation',
+  when: {
     type: 'test',
     subject: { type: 'reference', path: ['@self'] },
     negate: false,
@@ -293,8 +304,7 @@ validate: [
       arguments: [{ minLength: 12 }]
     }
   },
-  thenValue: 'Valid password',
-  elseValue: false
+  message: 'Valid password'
 }
 ```
 

--- a/packages/form-engine/docs/form-engine.md
+++ b/packages/form-engine/docs/form-engine.md
@@ -1,0 +1,146 @@
+# Form Engine with AST-Based Runtime
+
+## Overview
+This project is building a declarative, server-side form system that uses a two-stage AST
+(Abstract Syntax Tree) approach to handle complex, multi-step government-style forms.
+Think of it as a form engine that transforms JSON configuration into intelligent,
+validated form flows with minimal runtime overhead.
+
+## The Problem We're Solving
+Building complex multi-step forms (like government assessments, applications, or wizards) typically involves:
+- Tons of imperative validation logic scattered across controllers
+- Complex conditional field dependencies that are hard to maintain
+- Difficulty in versioning and migrating form data structures
+- Performance issues with large, dynamic forms
+- Repetitive code for common patterns (save draft, validation, navigation)
+
+## The Solution: Two-Stage AST Processing
+### Stage 1: Compilation (Build Time)
+When a form definition (JSON) is loaded, we:
+1. **Parse** the JSON into an Abstract Syntax Tree
+2. **Analyze** dependencies between fields, creating a topologically-sorted dependency graph
+3. **Generate** optimized lambda functions for each field's validation, visibility, and value calculation
+4. **Prepare** the form for efficient runtime evaluation
+
+This happens once when the form is loaded, not on every request.
+
+### Stage 2: Evaluation (Runtime)
+When a user interacts with the form, we:
+1. **Provide context** to the pre-compiled AST (user answers, external data, request data)
+2. **Evaluate** only what's needed using the generated lambda functions
+3. **Calculate** field states, validation results, and navigation paths efficiently
+4. **Return** server-rendered HTML with the appropriate form state
+
+## Key Architecture Decisions
+
+### Server-Side Rendering
+This is a **server-rendered** form system, not a SPA. Each step is a full page load, with the server maintaining form state and handling all logic. This ensures:
+- Accessibility by default
+- Works without JavaScript
+- Progressive enhancement possible
+- Consistent validation between client and server
+
+### Declarative Configuration
+Forms are defined declaratively in TypeScript (compiling to JSON), not imperatively in code:
+
+```typescript
+// Instead of imperative validation logic scattered in controllers...
+if (req.body.age < 18 && req.body.parentalConsent !== 'yes') {
+  errors.push('Parental consent required')
+}
+
+// You declare the rule once with the field
+field({
+  code: 'parental_consent',
+  dependent: when(Answer('age').match(Condition.LessThan(18))),
+  validate: [
+    validation({
+      when: Self().not.match(Condition.Equals('yes')),
+      message: 'Parental consent required for minors'
+    })
+  ]
+})
+```
+
+### Dependency Graph Resolution
+The AST automatically:
+- Identifies all data dependencies between fields
+- Topologically sorts them to resolve in the correct order
+- Ensures circular dependencies are caught at compile time
+- Optimizes evaluation to only recalculate what's changed
+
+### Collections and Dynamic Content
+The system handles dynamic, repeating sections through collection blocks that:
+- Generate fields dynamically based on data arrays
+- Maintain proper namespacing and validation per item
+- Handle add/edit/delete operations declaratively
+- Scale efficiently even with large collections
+
+## Core Concepts
+
+### Journey → Step → Block/Field Hierarchy
+```
+Journey (Complete multi-step flow)
+├── Step (Individual page)
+│   ├── Block (UI component)
+│   ├── Field (Form input with validation)
+│   └── CollectionBlock (Dynamic repeated sections)
+└── Child Journey (Sub-flow within main journey)
+```
+
+### Reference System
+A unified way to reference data throughout the form:
+- `Self()` - Current field's value
+- `Answer('field_name')` - Other field values
+- `Data('source.path')` - External data loaded at step level
+- `Item()` - Current item in a collection loop
+- `Post()`, `Params()`, `Query()` - HTTP request data
+
+### Validation as Data
+Validation rules are data, not code, making them:
+- Testable in isolation
+- Reusable across fields
+- Composable into complex rules
+- Versionable with the form definition
+
+## Benefits of This Approach
+
+### Performance
+- **Compile once, evaluate many**: Heavy lifting done at form load, not per request
+- **Selective evaluation**: Only recalculate affected fields when data changes
+- **Optimized dependency resolution**: No redundant calculations
+
+### Maintainability
+- **Single source of truth**: All form logic in one declarative structure
+- **Clear data flow**: Dependencies are explicit and traceable
+- **Versioning built-in**: Form definitions can be versioned and migrated
+
+### Developer Experience
+- **TypeScript-first**: Full type safety with generated types from definitions
+- **Composable abstractions**: Reuse validation rules, conditions, and transformers
+- **Predictable behavior**: Declarative approach reduces surprises
+
+### Flexibility
+- **Extensible**: Register custom validators, transformers, and blocks
+- **Framework agnostic**: Can integrate with any Node.js server framework
+- **Progressive enhancement**: Start server-only, add client features as needed
+
+## Use Cases
+This system is particularly well-suited for:
+- Government forms and assessments
+- Multi-step application processes
+- Complex conditional wizards
+- Forms requiring audit trails and versioning
+- High-stakes forms where validation consistency is critical
+
+## Technical Stack
+- **Runtime**: Node.js with server-side rendering
+- **Templates**: Nunjucks for HTML generation
+- **Configuration**: TypeScript → JSON
+- **State Management**: Server-side sessions/database
+- **Validation**: AST-based evaluation engine
+
+## The Vision
+Build forms by describing *what* they should do, not *how* to do it. Let the AST handle
+the complexity of dependency resolution, validation ordering, and state management.
+Focus on the business logic, not the plumbing.

--- a/packages/form-engine/docs/journeys-and-steps.md
+++ b/packages/form-engine/docs/journeys-and-steps.md
@@ -1,6 +1,7 @@
 # Journeys and Steps Documentation
 
 ## Overview
+
 The form system is built on a hierarchical structure where **Journeys** represent
 complete multi-step form flows (like wizards), and **Steps** are the individual pages
 within those journeys. This architecture enables complex, branching form flows with
@@ -17,6 +18,7 @@ Journey (Complete flow)
 ```
 
 ## Journeys
+
 Journeys are the top-level containers that define an entire form flow from start to finish.
 They orchestrate how users move through your forms, managing the overall structure and flow control.
 
@@ -56,6 +58,7 @@ const registrationJourney = journey({
 ```
 
 ### Journey with Child Journeys
+
 Child journeys allow you to compose complex flows from smaller, sub-journeys.
 They can be conditionally included based on user data or choices using each sub-journey's guard.
 
@@ -125,6 +128,7 @@ journey({
 ```
 
 ## Steps
+
 Steps represent individual pages in your form journey. Each step contains blocks (UI components),
 handles data loading, defines transitions to other steps, and manages validation.
 
@@ -158,13 +162,19 @@ const personalDetailsStep = step({
       variant: 'text',
       code: 'first_name',
       label: 'First Name',
-      validate: [ when(Self().not.match(Condition.IsRequired())).then('First name is required') ],
+      validate: [ validation({
+        when: Self().not.match(Condition.IsRequired()),
+        message: 'First name is required'
+      }) ],
     }),
     field({
       variant: 'text',
       code: 'last_name',
       label: 'Last Name',
-      validate: [ when(Self().not.match(Condition.IsRequired())).then('Last name is required') ],
+      validate: [ validation({
+        when: Self().not.match(Condition.IsRequired()),
+        message: 'Last name is required'
+      }) ],
     }),
     block({
       variant: 'button-group',

--- a/packages/form-engine/docs/validation-system.md
+++ b/packages/form-engine/docs/validation-system.md
@@ -1,0 +1,221 @@
+# Validation System Documentation
+
+## Overview
+The form engine uses a structured validation system with `ValidationExpr` objects
+that support both regular validations and submission-only validations. This
+system allows for precise control over when validation rules are applied and provides
+a clear separation between journey traversal validation and final submission validation.
+
+## ValidationExpr Structure
+Each validation rule is represented as a `ValidationExpr` with the following structure:
+
+```typescript
+interface ValidationExpr {
+  type: 'validation'                    // Type identifier
+  when: PredicateExpr                   // Condition that triggers validation failure
+  message: string                       // Error message to display
+  submissionOnly?: boolean              // Optional: only check at submission time
+}
+```
+
+## Creating Validation Rules
+Use the `validation()` builder function to create validation rules:
+
+```typescript
+import { validation, field } from '../builders'
+import { Answer, Self } from '../helpers/referenceHelpers'
+import { Condition } from '../conditions'
+
+const emailField = field({
+  code: 'email',
+  variant: 'govukTextInput',
+  label: 'Email address',
+  validate: [
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: 'Enter your email address'
+    }),
+    validation({
+      when: Self().not.match(Condition.Email.IsValid()),
+      message: 'Enter a valid email address'
+    })
+  ]
+})
+```
+
+## Validation Types
+
+### Regular Validations
+Regular validations are checked both during journey path traversal and at submission time.
+These should be used for standard field validation like required fields, format validation, etc.
+
+```typescript
+validation({
+  when: Self().not.match(Condition.IsRequired()),
+  message: 'This field is required'
+})
+```
+
+### Submission-Only Validations
+Submission-only validations are marked with `submissionOnly: true` and are only checked
+when the user submits the form, not during journey path traversal.
+This is useful for validations that:
+
+- Make external API calls (like username uniqueness checks)
+- Depend on data that may change between form steps
+- Are expensive to compute
+
+```typescript
+validation({
+  when: Self().not.match(Condition.Username.IsUnique()),
+  message: 'This username is already taken',
+  submissionOnly: true
+})
+```
+
+## Journey Path Traversal vs Submission
+The form engine validates that users can legitimately reach each step by re-running
+validations during journey path traversal. However, some validations (like external API calls)
+should not be re-checked during this process:
+
+### Journey Traversal Validation
+- Checks basic field requirements and format
+- Ensures user followed the correct path through the form
+- Uses only validations where `submissionOnly` is false or undefined
+
+### Submission Validation
+- Runs ALL validation rules (both regular and submission-only)
+- Performs final checks before data is processed
+- Includes expensive operations like uniqueness checks
+
+## Examples
+
+### Basic Field Validation
+```typescript
+const nameField = field({
+  code: 'full_name',
+  variant: 'govukTextInput',
+  label: 'Full name',
+  validate: [
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: 'Enter your full name'
+    }),
+    validation({
+      when: Self().not.match(Condition.String.HasMaxLength(100)),
+      message: 'Name must be 100 characters or less'
+    })
+  ]
+})
+```
+
+### Conditional Validation
+```typescript
+const ageField = field({
+  code: 'age',
+  variant: 'govukTextInput',
+  label: 'Age',
+  validate: [
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: 'Enter your age'
+    }),
+    validation({
+      when: Self().not.match(Condition.Number.IsInteger()),
+      message: 'Age must be a whole number'
+    }),
+    validation({
+      when: Self().not.match(Condition.Number.IsBetween(16, 120)),
+      message: 'Age must be between 16 and 120'
+    })
+  ]
+})
+```
+
+### Mixed Regular and Submission-Only Validation
+```typescript
+const usernameField = field({
+  code: 'username',
+  variant: 'govukTextInput',
+  label: 'Choose a username',
+  validate: [
+    // Regular validation - checked during traversal and submission
+    validation({
+      when: Self().not.match(Condition.IsRequired()),
+      message: 'Enter a username'
+    }),
+    validation({
+      when: Self().not.match(Condition.String.HasMinLength(3)),
+      message: 'Username must be at least 3 characters'
+    }),
+    validation({
+      when: Self().not.match(Condition.String.MatchesRegex(/^[a-zA-Z0-9_]+$/)),
+      message: 'Username can only contain letters, numbers, and underscores'
+    }),
+    // Submission-only validation - only checked at final submission
+    validation({
+      when: Self().not.match(Condition.IsUniqueUsername()),
+      message: 'This username is already taken',
+      submissionOnly: true
+    })
+  ]
+})
+```
+
+### Date Validation with Future Date Check
+```typescript
+const appointmentDateField = field({
+  code: 'appointment_date',
+  variant: 'govukDateInput',
+  label: 'Preferred appointment date',
+  validate: [
+    validation({
+      when: Self().not.match(Condition.Date.IsValid()),
+      message: 'Enter a valid date'
+    }),
+    validation({
+      when: Self().not.match(Condition.Date.IsFutureDate()),
+      message: 'Appointment date must be in the future',
+      submissionOnly: true  // Only check at submission as "future" changes over time
+    })
+  ]
+})
+```
+
+## Best Practices
+
+### When to Use Submission-Only Validations
+Use `submissionOnly: true` for validations that:
+
+1. **Make external API calls**: Uniqueness checks, service availability, etc.
+2. **Time-dependent validations**: Future date checks, age calculations, etc.
+3. **Expensive computations**: Complex calculations that shouldn't run repeatedly
+4. **Dynamic data**: Validations against data that may change between form steps
+
+### When to Use Regular Validations
+Use regular validations (default behavior) for:
+
+1. **Format validation**: Email format, phone numbers, postal codes
+2. **Required field checks**: Basic field presence validation
+3. **Static rules**: Length limits, character restrictions, etc.
+4. **Cross-field validation**: Between fields that don't change during the journey
+
+### Error Message Guidelines
+- Use clear, specific error messages
+- Follow GOV.UK Design System patterns for error messages (or have content designers write these!)
+- Be consistent with terminology across your form
+- Provide guidance on how to fix the error when possible
+
+```typescript
+// Avoid: Vague or technical
+validation({
+  when: Self().not.match(Condition.Email.IsValid()),
+  message: 'Invalid format'
+})
+
+// Good: Specific and actionable
+validation({
+  when: Self().not.match(Condition.Email.IsValid()),
+  message: 'Enter an email address in the correct format, like name@example.com'
+})
+```

--- a/packages/form-engine/src/form/builders/index.ts
+++ b/packages/form-engine/src/form/builders/index.ts
@@ -1,5 +1,11 @@
 import { finaliseBuilders } from './utils/finaliseBuilders'
-import { BlockDefinition, FieldBlockDefinition, JourneyDefinition, StepDefinition } from '../types/structures.type'
+import {
+  BlockDefinition,
+  FieldBlockDefinition,
+  JourneyDefinition,
+  StepDefinition,
+  ValidationExpr,
+} from '../types/structures.type'
 import { SkipValidationTransition, TransitionExpr, ValidatingTransition } from '../types/expressions.type'
 
 export function block<D extends BlockDefinition>(definition: Omit<D, 'type'>): D {
@@ -36,5 +42,12 @@ export function transition(definition: Omit<TransitionExpr, 'type'>): Transition
   return finaliseBuilders({
     ...definition,
     type: 'transition',
+  }) as any
+}
+
+export function validation(definition: Omit<ValidationExpr, 'type'>): ValidationExpr {
+  return finaliseBuilders({
+    ...definition,
+    type: 'validation',
   }) as any
 }

--- a/packages/form-engine/src/form/types/structures.type.ts
+++ b/packages/form-engine/src/form/types/structures.type.ts
@@ -121,8 +121,8 @@ export interface FieldBlockDefinition extends BlockDefinition {
   /** Conditional visibility - field is hidden when this evaluates to truthy */
   hidden?: ConditionalValue<any>
 
-  /** Array of validation error messages currently active on the field */
-  errors?: string[]
+  /** Array of validation errors currently active on the field */
+  errors?: readonly { message: string; details?: Record<string, any> }[]
 
   /** Array of validation rules to apply to the field value */
   validate?: ValidationExpr[]

--- a/packages/form-engine/src/form/types/structures.type.ts
+++ b/packages/form-engine/src/form/types/structures.type.ts
@@ -56,6 +56,26 @@ export interface CompositeBlockDefinition<B = BlockDefinition> extends BlockDefi
 }
 
 /**
+ * Represents a validation rule for a form field.
+ * Includes the validation logic, error message, and execution context.
+ */
+export interface ValidationExpr {
+  type: 'validation'
+
+  /** The predicate expression that determines if validation passes */
+  when: PredicateExpr | ConditionalExprBuilder
+
+  /** Error message to display when validation fails */
+  message: string
+
+  /**
+   * If true, this validation is only checked at submission time,
+   * not during journey path traversal. Defaults to false.
+   */
+  submissionOnly?: boolean
+}
+
+/**
  * Block definition for form field blocks.
  * Represents user input fields with validation and formatting.
  */
@@ -76,10 +96,10 @@ export interface FieldBlockDefinition extends BlockDefinition {
   errors?: string[]
 
   /** Array of validation rules to apply to the field value */
-  validate?: (ConditionalExpr | ConditionalExprBuilder)[]
+  validate?: ValidationExpr[]
 
   /** Marks field as dependent on other fields - used for validation ordering */
-  dependent?: ConditionalExpr | ConditionalExprBuilder
+  dependent?: PredicateTestExpr | PredicateTestExprBuilder
 }
 
 /**

--- a/packages/form-engine/src/form/types/structures.type.ts
+++ b/packages/form-engine/src/form/types/structures.type.ts
@@ -1,13 +1,14 @@
 import { ConditionalString, ConditionalValue } from './values.type'
 import {
-  ConditionalExpr,
   FunctionExpr,
   PipelineExpr,
+  PredicateExpr,
+  PredicateTestExpr,
   ReferenceExpr,
   TransformerExpr,
   TransitionExpr,
 } from './expressions.type'
-import { ConditionalExprBuilder } from '../builders/ConditionalExprBuilder'
+import { PredicateTestExprBuilder } from '../builders/PredicateTestExprBuilder'
 
 /**
  * Base interface for all block types in the form engine.
@@ -58,12 +59,34 @@ export interface CompositeBlockDefinition<B = BlockDefinition> extends BlockDefi
 /**
  * Represents a validation rule for a form field.
  * Includes the validation logic, error message, and execution context.
+ *
+ * @example
+ * // Using fluent builder syntax
+ * validation({
+ *   when: Answer('age').not.match(Condition.Number.IsBetween(18, 65)),
+ *   message: 'Age must be between 18 and 65',
+ *   details: { field: 'age', errorType: 'range' }
+ * })
+ *
+ * @example
+ * // Using object notation
+ * {
+ *   type: 'validation',
+ *   when: {
+ *     type: 'test',
+ *     subject: { type: 'reference', path: ['answers', 'email'] },
+ *     negate: true,
+ *     condition: { type: 'function', name: 'isRequired', arguments: [] }
+ *   },
+ *   message: 'Email address is required',
+ *   submissionOnly: false
+ * }
  */
 export interface ValidationExpr {
   type: 'validation'
 
   /** The predicate expression that determines if validation passes */
-  when: PredicateExpr | ConditionalExprBuilder
+  when: PredicateExpr | PredicateTestExprBuilder
 
   /** Error message to display when validation fails */
   message: string
@@ -73,6 +96,12 @@ export interface ValidationExpr {
    * not during journey path traversal. Defaults to false.
    */
   submissionOnly?: boolean
+
+  /**
+   * Optional details that can be used by components for enhanced error handling.
+   * For example, to specify which sub-field in a composite field should be highlighted.
+   */
+  details?: Record<string, any>
 }
 
 /**


### PR DESCRIPTION
- Add support for `submissionOnly` validations that are validations should only run on initial submission, not as part of latter re-validations (journey path traversal)
- Add support for `details` for providing additional details alongside an error
- Improve documentation