### PR TITLE
Add new normalisers

### DIFF
--- a/packages/form-engine/src/core/ast/CompiledAST.ts
+++ b/packages/form-engine/src/core/ast/CompiledAST.ts
@@ -1,5 +1,6 @@
 import { transformToAst } from '@form-engine/core/ast/transformer/transformToAst'
 import { resolveSelfReferences } from '@form-engine/core/ast/normalizers/ResolveSelfReferences'
+import { convertFormattersToPipeline } from '@form-engine/core/ast/normalizers/ConvertFormattersToPipeline'
 import NodeRegistry from '@form-engine/core/ast/registration/NodeRegistry'
 import RegistrationTraverser from '@form-engine/core/ast/registration/RegistrationTraverser'
 import { JourneyASTNode } from '@form-engine/core/types/structures.type'
@@ -16,6 +17,7 @@ export default class CompiledAST {
 
     // 1B. Normalise AST
     resolveSelfReferences(root)
+    convertFormattersToPipeline(root)
 
     // 2. Registration
     const nodeRegistry = RegistrationTraverser.buildRegistry(root)

--- a/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.test.ts
+++ b/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.test.ts
@@ -1,0 +1,134 @@
+import { ExpressionType } from '@form-engine/form/types/enums'
+import { isExpressionNode } from '@form-engine/core/typeguards/expression-nodes'
+import { ASTTestFactory } from '@form-engine/test-utils/ASTTestFactory'
+import { ASTNodeType } from '@form-engine/core/types/enums'
+import { addSelfValueToFields } from './AddSelfValueToFields'
+
+describe('AddSelfValueToFields', () => {
+  beforeEach(() => {
+    ASTTestFactory.resetIds()
+  })
+
+  describe('addSelfValueToFields', () => {
+    it('adds Self() reference to fields without explicit value', () => {
+      const field = ASTTestFactory.block('textInput', 'field')
+        .withId(1)
+        .withCode('username')
+        .withLabel('Username')
+        .build()
+
+      addSelfValueToFields(field)
+
+      const value = field.properties.get('value')
+      expect(isExpressionNode(value)).toBe(true)
+      expect(value).toMatchObject({
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.REFERENCE,
+      })
+      expect(value.properties.get('path')).toEqual(['answers', '@self'])
+    })
+
+    it('does not override existing value', () => {
+      const explicitValue = 'preset value'
+      const field = ASTTestFactory.block('textInput', 'field')
+        .withId(2)
+        .withCode('username')
+        .withLabel('Username')
+        .withProperty('value', explicitValue)
+        .build()
+
+      addSelfValueToFields(field)
+
+      expect(field.properties.get('value')).toBe(explicitValue)
+    })
+
+    it('ignores blocks without code (non-fields)', () => {
+      const block = ASTTestFactory.block('heading', 'basic').withId(3).withProperty('text', 'Welcome').build()
+
+      const originalValue = block.properties.get('value')
+      addSelfValueToFields(block)
+
+      expect(block.properties.get('value')).toBe(originalValue)
+    })
+
+    it('handles fields with explicit undefined value', () => {
+      const field = ASTTestFactory.block('textInput', 'field')
+        .withId(4)
+        .withCode('username')
+        .withLabel('Username')
+        .withProperty('value', undefined)
+        .build()
+
+      addSelfValueToFields(field)
+
+      // undefined is treated as "no value", so should add Self()
+      const value = field.properties.get('value')
+      expect(isExpressionNode(value)).toBe(true)
+      expect(value.properties.get('path')).toEqual(['answers', '@self'])
+    })
+
+    it('processes blocks within collection templates', () => {
+      const itemTemplate = ASTTestFactory.block('textInput', 'field')
+        .withId(5)
+        .withCode('street')
+        .withLabel('Street')
+        .build()
+
+      const collectionBlock = ASTTestFactory.block('collection', 'collection')
+        .withId(6)
+        .withCode('addresses')
+        .withProperty('itemTemplate', itemTemplate)
+        .build()
+
+      const step = ASTTestFactory.step().withId(7).withProperty('blocks', [collectionBlock]).build()
+
+      const journey = ASTTestFactory.journey().withId(8).withProperty('steps', [step]).build()
+
+      addSelfValueToFields(journey)
+
+      const steps = journey.properties.get('steps')
+      const blocks = steps[0].properties.get('blocks')
+      const template = blocks[0].properties.get('itemTemplate')
+
+      // Item template field should have Self() added
+      const value = template.properties.get('value')
+      expect(isExpressionNode(value)).toBe(true)
+      expect(value.properties.get('path')).toEqual(['answers', '@self'])
+    })
+
+    it('handles nested fields in composite blocks', () => {
+      const nestedField1 = ASTTestFactory.block('textInput', 'field')
+        .withId(9)
+        .withCode('nested1')
+        .withLabel('Nested 1')
+        .build()
+
+      const nestedField2 = ASTTestFactory.block('textInput', 'field')
+        .withId(10)
+        .withCode('nested2')
+        .withLabel('Nested 2')
+        .withProperty('value', 'has value')
+        .build()
+
+      const compositeBlock = ASTTestFactory.block('group', 'composite')
+        .withId(11)
+        .withProperty('blocks', [nestedField1, nestedField2])
+        .build()
+
+      const step = ASTTestFactory.step().withId(12).withProperty('blocks', [compositeBlock]).build()
+
+      addSelfValueToFields(step)
+
+      const blocks = step.properties.get('blocks')[0].properties.get('blocks')
+
+      // First nested field should have Self() added
+      const field1Value = blocks[0].properties.get('value')
+      expect(isExpressionNode(field1Value)).toBe(true)
+      expect(field1Value.properties.get('path')).toEqual(['answers', '@self'])
+
+      // Second nested field should keep its existing value
+      const field2Value = blocks[1].properties.get('value')
+      expect(field2Value).toBe('has value')
+    })
+  })
+})

--- a/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.test.ts
+++ b/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.test.ts
@@ -28,7 +28,7 @@ describe('AddSelfValueToFields', () => {
       expect(value.properties.get('path')).toEqual(['answers', '@self'])
     })
 
-    it('does not override existing value', () => {
+    it('overrides existing value with Self() reference', () => {
       const explicitValue = 'preset value'
       const field = ASTTestFactory.block('textInput', 'field')
         .withId(2)
@@ -39,7 +39,9 @@ describe('AddSelfValueToFields', () => {
 
       addSelfValueToFields(field)
 
-      expect(field.properties.get('value')).toBe(explicitValue)
+      const value = field.properties.get('value')
+      expect(isExpressionNode(value)).toBe(true)
+      expect(value.properties.get('path')).toEqual(['answers', '@self'])
     })
 
     it('ignores blocks without code (non-fields)', () => {
@@ -51,7 +53,7 @@ describe('AddSelfValueToFields', () => {
       expect(block.properties.get('value')).toBe(originalValue)
     })
 
-    it('handles fields with explicit undefined value', () => {
+    it('adds Self() even when value is undefined', () => {
       const field = ASTTestFactory.block('textInput', 'field')
         .withId(4)
         .withCode('username')
@@ -61,7 +63,6 @@ describe('AddSelfValueToFields', () => {
 
       addSelfValueToFields(field)
 
-      // undefined is treated as "no value", so should add Self()
       const value = field.properties.get('value')
       expect(isExpressionNode(value)).toBe(true)
       expect(value.properties.get('path')).toEqual(['answers', '@self'])
@@ -126,9 +127,10 @@ describe('AddSelfValueToFields', () => {
       expect(isExpressionNode(field1Value)).toBe(true)
       expect(field1Value.properties.get('path')).toEqual(['answers', '@self'])
 
-      // Second nested field should keep its existing value
+      // Second nested field should also have Self() added (overriding existing value)
       const field2Value = blocks[1].properties.get('value')
-      expect(field2Value).toBe('has value')
+      expect(isExpressionNode(field2Value)).toBe(true)
+      expect(field2Value.properties.get('path')).toEqual(['answers', '@self'])
     })
   })
 })

--- a/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.ts
+++ b/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.ts
@@ -1,0 +1,53 @@
+import { ASTNode } from '@form-engine/core/types/engine.type'
+import { structuralTraverse, StructuralVisitResult } from '@form-engine/core/ast/traverser/StructuralTraverser'
+import { isBlockStructNode } from '@form-engine/core/typeguards/structure-nodes'
+import { ExpressionType } from '@form-engine/form/types/enums'
+import { ReferenceASTNode } from '@form-engine/core/types/expressions.type'
+import { ASTNodeType } from '@form-engine/core/types/enums'
+
+/**
+ * Normalizer that adds Self() as the value for field blocks.
+ * This ensures fields automatically display their answer value without needing explicit configuration.
+ */
+export function addSelfValueToFields(root: ASTNode): void {
+  structuralTraverse(root, {
+    enterNode: node => {
+      // Only process field blocks
+      if (!isBlockStructNode(node) || node.blockType !== 'field') {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      if (!node.properties) {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      // Only process blocks that have a 'code' (i.e., fields)
+      const code = node.properties.get('code')
+      if (!code) {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      // If there's already a value property, don't override it
+      const existingValue = node.properties.get('value')
+      if (existingValue !== undefined) {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      // Create a Self() reference node
+      const selfReference: ReferenceASTNode = {
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.REFERENCE,
+        properties: new Map([['path', ['answers', '@self']]]),
+        raw: {
+          type: ExpressionType.REFERENCE,
+          path: ['answers', '@self'],
+        },
+      }
+
+      // Add the Self() reference as the value directly on the node
+      node.properties.set('value', selfReference)
+
+      return StructuralVisitResult.CONTINUE
+    },
+  })
+}

--- a/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.ts
+++ b/packages/form-engine/src/core/ast/normalizers/AddSelfValueToFields.ts
@@ -27,12 +27,6 @@ export function addSelfValueToFields(root: ASTNode): void {
         return StructuralVisitResult.CONTINUE
       }
 
-      // If there's already a value property, don't override it
-      const existingValue = node.properties.get('value')
-      if (existingValue !== undefined) {
-        return StructuralVisitResult.CONTINUE
-      }
-
       // Create a Self() reference node
       const selfReference: ReferenceASTNode = {
         type: ASTNodeType.EXPRESSION,

--- a/packages/form-engine/src/core/ast/normalizers/ConvertFormattersToPipeline.test.ts
+++ b/packages/form-engine/src/core/ast/normalizers/ConvertFormattersToPipeline.test.ts
@@ -1,0 +1,301 @@
+import { convertFormattersToPipeline } from '@form-engine/core/ast/normalizers/ConvertFormattersToPipeline'
+import { ASTTestFactory } from '@form-engine/test-utils/ASTTestFactory'
+import { FunctionType, ExpressionType } from '@form-engine/form/types/enums'
+import InvalidNodeError from '@form-engine/errors/InvalidNodeError'
+import { PipelineASTNode, ReferenceASTNode } from '@form-engine/core/types/expressions.type'
+import { isPipelineExprNode, isReferenceExprNode } from '@form-engine/core/typeguards/expression-nodes'
+import { isTransformerFunctionNode } from '@form-engine/core/typeguards/function-nodes'
+
+describe('convertFormattersToPipeline', () => {
+  it('converts single formatter to pipeline with POST reference', () => {
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(1)
+      .withCode('myField')
+      .withProperty('formatters', [formatter])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    const formatPipeline = field.properties.get('formatPipeline') as PipelineASTNode
+    expect(isPipelineExprNode(formatPipeline)).toBe(true)
+
+    // Check input is POST reference
+    const input = formatPipeline.properties.get('input') as ReferenceASTNode
+    expect(isReferenceExprNode(input)).toBe(true)
+    expect(input.properties.get('path')).toEqual(['post', 'myField'])
+
+    // Check steps
+    const steps = formatPipeline.properties.get('steps') as any[]
+    const originalFormatters = field.properties.get('formatters') as any[]
+
+    expect(steps).toHaveLength(1)
+    expect(steps).not.toBe(originalFormatters)
+    expect(isTransformerFunctionNode(steps[0])).toBe(true)
+
+    const stepProps = steps[0].properties as Map<string, unknown>
+    expect(stepProps).not.toBe(formatter.properties)
+    expect(stepProps.get('name')).toBe('trim')
+    expect(stepProps.get('arguments')).toEqual([])
+
+    // Original formatters should still be present
+    expect(field.properties.get('formatters')).toEqual([formatter])
+  })
+
+  it('converts multiple formatters to pipeline steps in order', () => {
+    const formatter1 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+    const formatter2 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'toUpperCase')
+    const formatter3 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'removeSpaces')
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(2)
+      .withCode('userInput')
+      .withProperty('formatters', [formatter1, formatter2, formatter3])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    const formatPipeline = field.properties.get('formatPipeline') as PipelineASTNode
+    const steps = formatPipeline.properties.get('steps') as any[]
+
+    expect(steps).toHaveLength(3)
+    expect(stepName(steps[0])).toBe('trim')
+    expect(stepName(steps[1])).toBe('toUpperCase')
+    expect(stepName(steps[2])).toBe('removeSpaces')
+  })
+
+  it('preserves formatter arguments in pipeline steps', () => {
+    const formatter1 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'substring', [0, 10])
+    const formatter2 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'padEnd', [20, '.'])
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(3)
+      .withCode('limitedText')
+      .withProperty('formatters', [formatter1, formatter2])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    const formatPipeline = field.properties.get('formatPipeline') as PipelineASTNode
+    const steps = formatPipeline.properties.get('steps') as any[]
+
+    expect(stepArgs(steps[0])).toEqual([0, 10])
+    expect(stepArgs(steps[1])).toEqual([20, '.'])
+  })
+
+  it('handles formatters with complex argument expressions', () => {
+    const refArg = ASTTestFactory.reference(['data', 'maxLength'])
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'truncate', [refArg, '...'])
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(4)
+      .withCode('description')
+      .withProperty('formatters', [formatter])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    const formatPipeline = field.properties.get('formatPipeline') as PipelineASTNode
+    const steps = formatPipeline.properties.get('steps') as any[]
+
+    expect(stepName(steps[0])).toBe('truncate')
+    const args = stepArgs(steps[0])
+    expect(args).toHaveLength(2)
+    expect(args[0]).toBe(refArg)
+    expect(args[1]).toBe('...')
+  })
+
+  it('does not modify fields without formatters', () => {
+    const field = ASTTestFactory.block('TextInput', 'field').withId(5).withCode('plainField').build()
+
+    const originalProps = new Map(field.properties)
+    convertFormattersToPipeline(field)
+
+    expect(field.properties.has('formatPipeline')).toBe(false)
+    expect(field.properties).toEqual(originalProps)
+  })
+
+  it('does not modify fields with empty formatters array', () => {
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(6)
+      .withCode('emptyFormatters')
+      .withProperty('formatters', [])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    expect(field.properties.has('formatPipeline')).toBe(false)
+  })
+
+  it('processes multiple fields in a journey', () => {
+    const formatter1 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+    const formatter2 = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'toUpperCase')
+
+    const field1 = ASTTestFactory.block('TextInput', 'field')
+      .withId(7)
+      .withCode('field1')
+      .withProperty('formatters', [formatter1])
+      .build()
+
+    const field2 = ASTTestFactory.block('TextInput', 'field')
+      .withId(8)
+      .withCode('field2')
+      .withProperty('formatters', [formatter2])
+      .build()
+
+    const field3 = ASTTestFactory.block('TextInput', 'field').withId(9).withCode('field3').build()
+
+    const step = ASTTestFactory.step().withId(10).withProperty('blocks', [field1, field2, field3]).build()
+
+    const journey = ASTTestFactory.journey().withId(11).withProperty('steps', [step]).build()
+
+    convertFormattersToPipeline(journey)
+
+    // Check field1
+    const pipeline1 = field1.properties.get('formatPipeline') as PipelineASTNode
+    expect(isPipelineExprNode(pipeline1)).toBe(true)
+    const input1 = pipeline1.properties.get('input') as ReferenceASTNode
+    expect(input1.properties.get('path')).toEqual(['post', 'field1'])
+
+    // Check field2
+    const pipeline2 = field2.properties.get('formatPipeline') as PipelineASTNode
+    expect(isPipelineExprNode(pipeline2)).toBe(true)
+    const input2 = pipeline2.properties.get('input') as ReferenceASTNode
+    expect(input2.properties.get('path')).toEqual(['post', 'field2'])
+
+    // Check field3 has no pipeline
+    expect(field3.properties.has('formatPipeline')).toBe(false)
+  })
+
+  it('throws when field with formatters has no code', () => {
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+
+    const field = ASTTestFactory.block('TextInput', 'field').withId(12).withProperty('formatters', [formatter]).build()
+
+    expect(() => convertFormattersToPipeline(field)).toThrow(InvalidNodeError)
+
+    try {
+      convertFormattersToPipeline(field)
+    } catch (e) {
+      const err = e as InvalidNodeError
+      expect(err.message).toMatch(/Field with formatters must have a code property/)
+    }
+  })
+
+  it('handles fields with dynamic code expressions', () => {
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+
+    const codeExpr = ASTTestFactory.expression(ExpressionType.FORMAT)
+      .withId(13)
+      .withProperty('text', 'address_%1')
+      .withProperty('args', [ASTTestFactory.reference(['@scope', '@index'])])
+      .build()
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(14)
+      .withCode(codeExpr)
+      .withProperty('formatters', [formatter])
+      .build()
+
+    convertFormattersToPipeline(field)
+
+    const formatPipeline = field.properties.get('formatPipeline') as PipelineASTNode
+    expect(isPipelineExprNode(formatPipeline)).toBe(true)
+
+    // Check input is POST reference with the expression as the path segment
+    const input = formatPipeline.properties.get('input') as ReferenceASTNode
+    expect(isReferenceExprNode(input)).toBe(true)
+    const path = input.properties.get('path') as any[]
+    expect(path[0]).toBe('post')
+    expect(path[1]).toBe(codeExpr) // The expression node itself is used
+
+    // Check steps
+    const steps = formatPipeline.properties.get('steps') as any[]
+    expect(steps).toHaveLength(1)
+    expect(stepName(steps[0])).toBe('trim')
+    expect(stepArgs(steps[0])).toEqual([])
+  })
+
+  it('handles collection blocks with formatters', () => {
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+
+    const itemField = ASTTestFactory.block('TextInput', 'field')
+      .withId(17)
+      .withCode('itemName')
+      .withProperty('formatters', [formatter])
+      .build()
+
+    const collectionBlock = ASTTestFactory.block('collection', 'collection')
+      .withId(18)
+      .withProperty('itemTemplate', itemField)
+      .build()
+
+    convertFormattersToPipeline(collectionBlock)
+
+    const formatPipeline = itemField.properties.get('formatPipeline') as PipelineASTNode
+    expect(isPipelineExprNode(formatPipeline)).toBe(true)
+
+    const input = formatPipeline.properties.get('input') as ReferenceASTNode
+    expect(input.properties.get('path')).toEqual(['post', 'itemName'])
+  })
+
+  it('preserves all other field properties when adding formatPipeline', () => {
+    const formatter = ASTTestFactory.functionExpression(FunctionType.TRANSFORMER, 'trim')
+
+    const validationExpr = ASTTestFactory.expression(ExpressionType.VALIDATION).withId(19).build()
+
+    const field = ASTTestFactory.block('TextInput', 'field')
+      .withId(20)
+      .withCode('fullField')
+      .withLabel('Full Field')
+      .withProperty('hint', 'Enter your text')
+      .withProperty('required', true)
+      .withProperty('validation', validationExpr)
+      .withProperty('formatters', [formatter])
+      .build()
+
+    const originalKeys = Array.from(field.properties.keys())
+
+    convertFormattersToPipeline(field)
+
+    // All original properties should still exist
+    for (const key of originalKeys) {
+      expect(field.properties.has(key)).toBe(true)
+    }
+
+    // Plus the new formatPipeline
+    expect(field.properties.has('formatPipeline')).toBe(true)
+
+    // Verify specific properties are unchanged
+    expect(field.properties.get('label')).toBe('Full Field')
+    expect(field.properties.get('hint')).toBe('Enter your text')
+    expect(field.properties.get('required')).toBe(true)
+    expect(field.properties.get('validation')).toBe(validationExpr)
+  })
+})
+
+function stepName(step: any): string | undefined {
+  if (isTransformerFunctionNode(step)) {
+    return step.properties?.get('name')
+  }
+
+  if (step && typeof step === 'object') {
+    return step.name
+  }
+
+  return undefined
+}
+
+function stepArgs(step: any): unknown[] {
+  if (isTransformerFunctionNode(step)) {
+    const args = step.properties?.get('arguments')
+    return Array.isArray(args) ? args : []
+  }
+
+  if (step && typeof step === 'object' && Array.isArray(step.args)) {
+    return step.args
+  }
+
+  return []
+}

--- a/packages/form-engine/src/core/ast/normalizers/ConvertFormattersToPipeline.ts
+++ b/packages/form-engine/src/core/ast/normalizers/ConvertFormattersToPipeline.ts
@@ -1,0 +1,87 @@
+import { ASTNode } from '@form-engine/core/types/engine.type'
+import { structuralTraverse, StructuralVisitResult } from '@form-engine/core/ast/traverser/StructuralTraverser'
+import { isBlockStructNode } from '@form-engine/core/typeguards/structure-nodes'
+import InvalidNodeError from '@form-engine/errors/InvalidNodeError'
+import { ASTNodeType } from '@form-engine/core/types/enums'
+import { ExpressionType } from '@form-engine/form/types/enums'
+import { PipelineASTNode, ReferenceASTNode } from '@form-engine/core/types/expressions.type'
+
+/**
+ * Converts field formatters arrays into Pipeline expressions during normalization.
+ *
+ * This transformation ensures that formatters are treated as regular expression
+ * nodes by the runtime, allowing the dependency graph to track their dependencies
+ * and the evaluation engine to handle them consistently.
+ *
+ * For each field with formatters:
+ * 1. Creates a Pipeline expression with Reference(['post', fieldCode]) as input
+ * 2. Converts each formatter function to a pipeline step
+ * 3. Stores the pipeline as the formatPipeline property
+ */
+export function convertFormattersToPipeline(root: ASTNode): void {
+  structuralTraverse(root, {
+    enterNode: (node, ctx) => {
+      // Only process field blocks
+      if (!isBlockStructNode(node) || node.blockType !== 'field') {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      if (!node.properties) {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      // Check if field has formatters
+      const formatters = node.properties.get('formatters')
+
+      if (!Array.isArray(formatters) || formatters.length === 0) {
+        return StructuralVisitResult.CONTINUE
+      }
+
+      // Get field code for POST reference
+      const fieldCode = node.properties.get('code')
+
+      if (!fieldCode) {
+        throw new InvalidNodeError({
+          message: 'Field with formatters must have a code property',
+          node,
+          path: ctx.path,
+        })
+      }
+
+      // Create the POST reference node
+      // The code can be either a string or an expression (e.g., Format('address_%1', Item.index()))
+      const postReference: ReferenceASTNode = {
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.REFERENCE,
+        properties: new Map([['path', ['post', fieldCode]]]),
+      }
+
+      const pipelineSteps = formatters.map(formatter => {
+        const properties = new Map(formatter.properties ?? [])
+        const args = properties.get('arguments')
+
+        properties.set('arguments', Array.isArray(args) ? [...args] : [])
+
+        return {
+          ...formatter,
+          properties,
+        }
+      })
+
+      // Create the pipeline node with normalized formatter steps
+      const pipelineNode: PipelineASTNode = {
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.PIPELINE,
+        properties: new Map<string, any>([
+          ['input', postReference],
+          ['steps', pipelineSteps],
+        ]),
+      }
+
+      // Store the pipeline as formatPipeline property
+      node.properties.set('formatPipeline', pipelineNode)
+
+      return StructuralVisitResult.CONTINUE
+    },
+  })
+}


### PR DESCRIPTION
- Added `AddSelfValueToField` which sets the `value` property for a field to a reference to the current field's answer.
- Added `ConvertFormattersToPipeline` which turns the `formatters` array property into a `Pipeline` driven by the POST value for that field, piped through the transformers.