### PR TITLE
Rework collections

### DIFF
--- a/packages/form-engine/docs/block-type-documentation.md
+++ b/packages/form-engine/docs/block-type-documentation.md
@@ -11,8 +11,7 @@ This document explains the four main block types and how they work together.
 ```
 Block (Base)
 ├── Field (Form inputs)
-├── CompositeBlock (Structural containers)
-└── CollectionBlock (Dynamic templated content)
+└── CompositeBlock (Structural containers)
 ```
 
 ## 1. Block (Base Type)
@@ -265,107 +264,3 @@ const billingAddressSection = block({
 #### `blocks`
 An array of child blocks (Fields, Blocks, or other CompositeBlocks) that are contained within this composite block.
 These child blocks are rendered as a group together.
-
-Here's a section for CollectionBlock following the same style:
-
-## 4. CollectionBlock
-
-CollectionBlocks iterate over arrays of data to generate repeated form sections dynamically.
-They use templates that are instantiated for each item in a collection, allowing forms to
-handle variable amounts of data efficiently.
-
-### Structure
-
-```typescript
-interface CollectionBlockDefinition extends BlockDefinition {
-  template: BlockDefinition[]             // Template blocks repeated for each item
-  fallbackTemplate?: BlockDefinition      // Optional template when collection is empty
-  collectionContext: CollectionOptions    // Configuration for data iteration
-}
-
-interface CollectionOptions {
-  collection: ReferenceExpr | PipelineExpr | Array     // Data source to iterate over
-  target?: ReferenceExpr | PipelineExpr | number       // Specific item/index
-}
-```
-
-### Examples
-
-```typescript
-// A collection that creates address fields for each address in the user's saved addresses
-const savedAddressesCollection = block({
-  variant: 'collection-block-group',
-  template: [
-    field({
-      variant: 'text',
-      code: Format('address_%1_street', Item('id')),
-      label: 'Street Address',
-      value: Item('street'),  // Pre-populate from collection item
-      validate: [
-        validation({
-          when: Self().not.match(Condition.IsRequired()),
-          message: 'Street address is required'
-        })
-      ]
-    }),
-    field({
-      variant: 'text',
-      code: Format('address_%1_city', Item('id')),
-      label: 'City',
-      value: Item('city')
-    }),
-    field({
-      variant: 'select',
-      code: Format('address_%1_country', Item('id')),
-      label: 'Country',
-      value: Item('country'),
-      items: Data('countries')
-    })
-  ],
-  collectionContext: {
-    collection: Answer('user_addresses')  // Array of address objects
-  }
-})
-
-// A collection with conditional fields based on item properties
-const drugUsageCollection = block({
-  variant: 'collection-block-group',
-  template: [
-    field({
-      variant: 'radio',
-      code: Format('drug_%1_last_used', Item('value')),
-      label: Format('When did they last use %1?', Item('value')),
-      items: [
-        { label: 'Used in the last 6 months', value: 'LAST_SIX' },
-        { label: 'Used more than 6 months ago', value: 'MORE_THAN_SIX' }
-      ],
-      validate: [
-        validation({
-          when: Self().not.match(Condition.IsRequired()),
-          message: 'Select when they last used this drug'
-        })
-      ]
-    }),
-  ],
-  collectionContext: {
-    collection: Answer('selected_drugs')  // Array of selected drug objects
-  }
-})
-```
-
-### Concepts
-
-#### `template`
-An array of blocks that serve as the blueprint for each item in the collection.
-The template is repeated once for every item, with `Item()` references resolved to the current item's data.
-Templates can contain any type of block: Fields, Blocks, or even nested CompositeBlocks.
-
-#### `collectionContext`
-Configuration that defines the data source and iteration behavior. The `collection` property
-specifies which array to iterate over, while the optional `target` property can focus on a specific item or index within the collection.
-
-#### Dynamic Field Generation
-
-When using fields in CollectionBlocks, it's worth giving them unique `code` attributes by combining the
-`Format()` expression with an `Item()` reference. This ensures each repeated
-field has a distinct identifier while maintaining a predictable naming pattern.

--- a/packages/form-engine/docs/custom-components.md
+++ b/packages/form-engine/docs/custom-components.md
@@ -39,7 +39,7 @@ export const myCustomComponent = buildComponent<MyComponentInterface>(
 ### Component Interface
 
 Every component needs a TypeScript interface that extends either `BlockDefinition`, `FieldBlockDefinition`,
-`CollectionBlockDefinition` or `CompositeBlockDefinition`. You can read up more on the distinction between these
+or `CompositeBlockDefinition`. You can read up more on the distinction between these
 types in the `block-type-documentation.md`:
 
 ```typescript

--- a/packages/form-engine/docs/form-engine.md
+++ b/packages/form-engine/docs/form-engine.md
@@ -70,11 +70,10 @@ The AST automatically:
 - Optimizes evaluation to only recalculate what's changed
 
 ### Collections and Dynamic Content
-The system handles dynamic, repeating sections through collection blocks that:
-- Generate fields dynamically based on data arrays
-- Maintain proper namespacing and validation per item
-- Handle add/edit/delete operations declaratively
-- Scale efficiently even with large collections
+The system handles dynamic, repeating sections through collection expressions that:
+- Generate structures dynamically from array data sources
+- Maintain proper namespacing and validation per item by scoping `Item()` references
+- Allow authors to express repetition declaratively within the AST
 
 ## Core Concepts
 
@@ -83,8 +82,7 @@ The system handles dynamic, repeating sections through collection blocks that:
 Journey (Complete multi-step flow)
 ├── Step (Individual page)
 │   ├── Block (UI component)
-│   ├── Field (Form input with validation)
-│   └── CollectionBlock (Dynamic repeated sections)
+│   └── Field (Form input with validation)
 └── Child Journey (Sub-flow within main journey)
 ```
 

--- a/packages/form-engine/src/core/ast/registration/RegistrationTraverser.test.ts
+++ b/packages/form-engine/src/core/ast/registration/RegistrationTraverser.test.ts
@@ -101,14 +101,5 @@ describe('RegistrationTraverser', () => {
       // Has conditional expressions
       expect(registry.size()).toBeGreaterThan(4) // journey + step + 2 blocks + expressions
     })
-
-    it('should handle withCollection scenario', () => {
-      const tree = ASTTestFactory.scenarios.withCollection()
-      const registry = RegistrationTraverser.buildRegistry(tree)
-
-      expect(tree.id).toBe(1)
-      // Collection with template blocks
-      expect(registry.size()).toBeGreaterThan(3)
-    })
   })
 })

--- a/packages/form-engine/src/core/ast/transformer/transformToAst.test.ts
+++ b/packages/form-engine/src/core/ast/transformer/transformToAst.test.ts
@@ -209,21 +209,8 @@ describe('ASTTransformer', () => {
               },
               {
                 type: StructureType.BLOCK,
-                variant: 'collection',
-                template: [
-                  {
-                    type: StructureType.BLOCK,
-                    variant: 'text',
-                    code: {
-                      type: ExpressionType.FORMAT,
-                      text: 'address_%1_street',
-                      args: [{ type: ExpressionType.REFERENCE, path: ['@item', 'id'] }],
-                    },
-                  },
-                ],
-                collectionContext: {
-                  collection: { type: ExpressionType.REFERENCE, path: ['answers', 'addresses'] },
-                },
+                variant: 'html',
+                content: '<p>Addresses will appear here</p>',
               },
             ],
             onSubmission: [

--- a/packages/form-engine/src/core/ast/transformer/transforms/transformExpressions.test.ts
+++ b/packages/form-engine/src/core/ast/transformer/transforms/transformExpressions.test.ts
@@ -1,4 +1,4 @@
-import { ExpressionType, LogicType, FunctionType } from '@form-engine/form/types/enums'
+import { ExpressionType, LogicType, FunctionType, StructureType } from '@form-engine/form/types/enums'
 import { ASTNodeType } from '@form-engine/core/types/enums'
 import {
   ConditionalASTNode,
@@ -17,6 +17,7 @@ import {
   transformValidation,
   transformPredicate,
   transformFunction,
+  transformCollection,
 } from './transformExpressions'
 
 describe('Expression Transformations', () => {
@@ -72,6 +73,50 @@ describe('Expression Transformations', () => {
       expect(result.properties.get('steps')[0]).toEqual({ name: 'trim', args: undefined })
       expect(result.properties.get('steps')[1]).toEqual({ name: 'toLowerCase', args: undefined })
       expect(result.properties.get('steps')[2]).toEqual({ name: 'capitalize', args: [true] })
+    })
+  })
+
+  describe('transformCollection()', () => {
+    it('should transform a collection expression with template and fallback', () => {
+      const collection = {
+        type: ExpressionType.COLLECTION,
+        collection: { type: ExpressionType.REFERENCE, path: ['answers', 'items'] },
+        template: [
+          {
+            type: StructureType.BLOCK,
+            variant: 'text',
+            code: 'item',
+          },
+        ],
+        fallback: [
+          {
+            type: StructureType.BLOCK,
+            variant: 'html',
+            content: 'No items',
+          },
+        ],
+      }
+
+      const result = transformCollection(collection, ['test'])
+
+      expect(result).toMatchObject({
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.COLLECTION,
+      })
+
+      const collectionProp = result.properties.get('collection') as ReferenceASTNode
+      expect(collectionProp).toMatchObject({
+        type: ASTNodeType.EXPRESSION,
+        expressionType: ExpressionType.REFERENCE,
+      })
+
+      const template = result.properties.get('template') as any[]
+      expect(Array.isArray(template)).toBe(true)
+      expect(template[0]).toMatchObject({ type: ASTNodeType.BLOCK, variant: 'text' })
+
+      const fallback = result.properties.get('fallback') as any[]
+      expect(Array.isArray(fallback)).toBe(true)
+      expect(fallback[0]).toMatchObject({ type: ASTNodeType.BLOCK, variant: 'html' })
     })
   })
 

--- a/packages/form-engine/src/core/ast/transformer/transforms/transformExpressions.ts
+++ b/packages/form-engine/src/core/ast/transformer/transforms/transformExpressions.ts
@@ -10,6 +10,7 @@ import {
   isPredicateXorExpr,
 } from '@form-engine/form/typeguards/predicates'
 import {
+  isCollectionExpr,
   isConditionalExpr,
   isPipelineExpr,
   isReferenceExpr,
@@ -17,6 +18,7 @@ import {
 } from '@form-engine/form/typeguards/expressions'
 import { isFunctionExpr } from '@form-engine/form/typeguards/functions'
 import {
+  CollectionASTNode,
   ConditionalASTNode,
   ExpressionASTNode,
   FunctionASTNode,
@@ -29,7 +31,7 @@ import { ASTNode } from '@form-engine/core/types/engine.type'
 
 /**
  * Transform Expression node: Dynamic values and logic
- * Handles references, pipelines, conditionals, validations, predicates, functions
+ * Handles references, pipelines, conditionals, collections, validations, predicates, functions
  */
 export function transformExpression(json: any, path: string[]): ExpressionASTNode {
   // Handle reference expressions
@@ -45,6 +47,11 @@ export function transformExpression(json: any, path: string[]): ExpressionASTNod
   // Handle conditional expressions
   if (isConditionalExpr(json)) {
     return transformConditional(json, path)
+  }
+
+  // Handle collection expressions
+  if (isCollectionExpr(json)) {
+    return transformCollection(json, path)
   }
 
   // Handle validation expressions
@@ -157,6 +164,41 @@ export function transformConditional(json: any, path: string[]): ConditionalASTN
   return {
     type: ASTNodeType.EXPRESSION,
     expressionType: LogicType.CONDITIONAL,
+    properties,
+    raw: json,
+  }
+}
+
+/**
+ * Transform Collection expression: Iterate over data to produce repeated templates
+ * Note this is _just_ the template, at runtime this template is used to generate
+ * actual nodes based on Collection content.
+ */
+export function transformCollection(json: any, path: string[]): CollectionASTNode {
+  const properties = new Map<string, ASTNode | any>()
+
+  // Transform the collection data source
+  properties.set('collection', transformValue(json.collection, [...path, 'collection']))
+
+  // Transform template blocks
+  if (json.template) {
+    const template = json.template.map((item: any, i: number) =>
+      transformNode(item, [...path, 'template', i.toString()]),
+    )
+    properties.set('template', template)
+  }
+
+  // Transform optional fallback blocks
+  if (json.fallback) {
+    const fallback = json.fallback.map((item: any, i: number) =>
+      transformNode(item, [...path, 'fallback', i.toString()]),
+    )
+    properties.set('fallback', fallback)
+  }
+
+  return {
+    type: ASTNodeType.EXPRESSION,
+    expressionType: ExpressionType.COLLECTION,
     properties,
     raw: json,
   }

--- a/packages/form-engine/src/core/ast/transformer/transforms/transformStructures.test.ts
+++ b/packages/form-engine/src/core/ast/transformer/transforms/transformStructures.test.ts
@@ -199,42 +199,6 @@ describe('Structure Transformations', () => {
       })
     })
 
-    it('should transform a collection block', () => {
-      const collectionBlock = {
-        type: StructureType.BLOCK,
-        variant: 'collection',
-        template: [
-          {
-            type: StructureType.BLOCK,
-            variant: 'text',
-            code: 'item_name',
-          },
-        ],
-        collectionContext: {
-          collection: { type: ExpressionType.REFERENCE, path: ['answers', 'items'] },
-        },
-      }
-
-      const result = transformBlock(collectionBlock, ['test']) as BlockASTNode
-
-      expect(result.type).toBe(ASTNodeType.BLOCK)
-      expect(result.variant).toBe('collection')
-      expect(result.blockType).toBe('collection')
-
-      const template = result.properties.get('template') as ASTNode[]
-      expect(template).toHaveLength(1)
-      expect(template[0]).toMatchObject({
-        type: ASTNodeType.BLOCK,
-        variant: 'text',
-      })
-
-      const collectionContext = result.properties.get('collectionContext') as any
-      expect(collectionContext.collection).toMatchObject({
-        type: ASTNodeType.EXPRESSION,
-        expressionType: 'ExpressionType.Reference',
-      })
-    })
-
     it('should transform a composite block', () => {
       const compositeBlock = {
         type: StructureType.BLOCK,

--- a/packages/form-engine/src/core/ast/transformer/transforms/transformStructures.ts
+++ b/packages/form-engine/src/core/ast/transformer/transforms/transformStructures.ts
@@ -1,8 +1,4 @@
-import {
-  isCollectionBlockDefinition,
-  isCompositeBlockDefinition,
-  isFieldBlockDefinition,
-} from '@form-engine/form/typeguards/structures'
+import { isCompositeBlockDefinition, isFieldBlockDefinition } from '@form-engine/form/typeguards/structures'
 import { transformProperties } from '@form-engine/core/ast/transformer/transformToAst'
 import { ASTNodeType } from '@form-engine/core/types/enums'
 import { BlockASTNode, JourneyASTNode, StepASTNode } from '@form-engine/core/types/structures.type'
@@ -18,12 +14,10 @@ export function transformBlock(json: any, path: string[]): BlockASTNode {
   const properties = transformProperties(dataProperties, [...path, 'block', variant])
 
   // Classify block for AST traversal optimization
-  let blockType: 'basic' | 'field' | 'collection' | 'composite'
+  let blockType: 'basic' | 'field' | 'composite'
 
   if (isFieldBlockDefinition(json)) {
     blockType = 'field'
-  } else if (isCollectionBlockDefinition(json)) {
-    blockType = 'collection'
   } else if (isCompositeBlockDefinition(json)) {
     blockType = 'composite'
   } else {

--- a/packages/form-engine/src/core/types/expressions.type.ts
+++ b/packages/form-engine/src/core/types/expressions.type.ts
@@ -40,6 +40,13 @@ export interface FormatASTNode extends ExpressionASTNode {
 }
 
 /**
+ * Collection Expression AST node
+ */
+export interface CollectionASTNode extends ExpressionASTNode {
+  expressionType: ExpressionType.COLLECTION
+}
+
+/**
  * Conditional Expression AST node
  */
 export interface ConditionalASTNode extends ExpressionASTNode {

--- a/packages/form-engine/src/core/types/structures.type.ts
+++ b/packages/form-engine/src/core/types/structures.type.ts
@@ -23,6 +23,6 @@ export interface StepASTNode extends ASTNode {
 export interface BlockASTNode extends ASTNode {
   type: ASTNodeType.BLOCK
   variant: string
-  blockType: 'basic' | 'field' | 'collection' | 'composite'
+  blockType: 'basic' | 'field' | 'composite'
   properties: Map<string, ASTNode | any>
 }

--- a/packages/form-engine/src/core/validation/schemas/expressions.schema.ts
+++ b/packages/form-engine/src/core/validation/schemas/expressions.schema.ts
@@ -57,7 +57,7 @@ export const PipelineExprSchema = z.looseObject({
  */
 export const CollectionExprSchema: z.ZodType<any> = z.looseObject({
   type: z.literal(ExpressionType.COLLECTION),
-  collection: z.union([ValueExprSchema, z.array(z.any())]),
+  collection: z.union([ReferenceExprSchema, PipelineExprSchema, z.array(z.any())]),
   template: z.array(z.any()),
   fallback: z.array(z.any()).optional(),
 })

--- a/packages/form-engine/src/core/validation/schemas/expressions.schema.ts
+++ b/packages/form-engine/src/core/validation/schemas/expressions.schema.ts
@@ -11,6 +11,7 @@ export const ValueExprSchema: z.ZodType<any> = z.lazy(() =>
     FormatExprSchema,
     TransformerFunctionExprSchema,
     PipelineExprSchema,
+    CollectionExprSchema,
     z.array(ValueExprSchema),
     z.string(),
     z.number(),
@@ -49,4 +50,14 @@ export const PipelineExprSchema = z.looseObject({
       args: z.array(ValueExprSchema).optional(),
     }),
   ),
+})
+
+/**
+ * @see {@link CollectionExpr}
+ */
+export const CollectionExprSchema: z.ZodType<any> = z.looseObject({
+  type: z.literal(ExpressionType.COLLECTION),
+  collection: z.union([ValueExprSchema, z.array(z.any())]),
+  template: z.array(z.any()),
+  fallback: z.array(z.any()).optional(),
 })

--- a/packages/form-engine/src/core/validation/schemas/structures.schema.ts
+++ b/packages/form-engine/src/core/validation/schemas/structures.schema.ts
@@ -33,19 +33,6 @@ export const ValidationExprSchema = z.looseObject({
 })
 
 /**
- * @see {@link CollectionOptions}
- */
-export const CollectionOptionsSchema = z.looseObject({
-  collection: z.union([
-    ReferenceExprSchema,
-    PipelineExprSchema,
-    z.array(z.string()),
-    z.array(z.number()),
-    z.array(z.looseObject({})),
-  ]),
-})
-
-/**
  * @see {@link BlockDefinition}
  */
 export const BlockSchema: z.ZodType<any> = z.lazy(() => {
@@ -71,12 +58,6 @@ export const BlockSchema: z.ZodType<any> = z.lazy(() => {
     dependent: PredicateTestExprSchema.optional(),
   })
 
-  const collectionBlockProps = z.looseObject({
-    template: z.array(BlockSchema),
-    fallbackTemplate: BlockSchema.optional(),
-    collectionContext: CollectionOptionsSchema,
-  })
-
   const compositeBlockProps = z.looseObject({
     blocks: z.array(BlockSchema),
   })
@@ -85,10 +66,6 @@ export const BlockSchema: z.ZodType<any> = z.lazy(() => {
     z.looseObject({
       ...baseBlock.shape,
       ...fieldBlockProps.shape,
-    }),
-    z.looseObject({
-      ...baseBlock.shape,
-      ...collectionBlockProps.shape,
     }),
     z.looseObject({
       ...baseBlock.shape,

--- a/packages/form-engine/src/form/builders/index.ts
+++ b/packages/form-engine/src/form/builders/index.ts
@@ -12,12 +12,14 @@ import {
 } from '../types/structures.type'
 import {
   AccessTransition,
+  CollectionExpr,
   FormatExpr,
   LoadTransition,
   NextExpr,
   SkipValidationTransition,
   SubmitTransition,
   ValidatingTransition,
+  ValueExpr,
 } from '../types/expressions.type'
 import { ExpressionType, StructureType, TransitionType } from '../types/enums'
 
@@ -171,5 +173,39 @@ export const Format = (text: string, ...args: ConditionalString[]): FormatExpr =
     type: ExpressionType.FORMAT,
     text,
     args,
+  }
+}
+
+/**
+ * Creates a collection expression that iterates over data to produce repeated templates.
+ * Collections allow dynamic generation of form elements based on arrays of data.
+ *
+ * @param collection - The data source to iterate over (array or expression)
+ * @param template - Template blocks to render for each item
+ * @param fallback - Optional fallback blocks when collection is empty
+ * @returns Collection expression
+ *
+ * @example
+ * // With fallback
+ * Collection({
+ *   collection: Data('items'),
+ *   template: [field({ code: 'item_name', variant: 'text' })],
+ *   fallback: [block({ variant: 'html', content: 'No items found' })]
+ * })
+ */
+export const Collection = <T = any>({
+  collection,
+  template,
+  fallback,
+}: {
+  collection: ValueExpr | any[]
+  template: T[]
+  fallback?: T[]
+}): CollectionExpr<T> => {
+  return {
+    type: ExpressionType.COLLECTION,
+    collection,
+    template,
+    fallback,
   }
 }

--- a/packages/form-engine/src/form/typeguards/expressions.ts
+++ b/packages/form-engine/src/form/typeguards/expressions.ts
@@ -5,6 +5,7 @@ import {
   FormatExpr,
   PipelineExpr,
   ConditionalExpr,
+  CollectionExpr,
   ValueExpr,
   NextExpr,
 } from '../types/expressions.type'
@@ -27,6 +28,10 @@ export function isConditionalExpr(obj: any): obj is ConditionalExpr {
   return obj != null && obj.type === LogicType.CONDITIONAL
 }
 
+export function isCollectionExpr(obj: any): obj is CollectionExpr {
+  return obj != null && obj.type === ExpressionType.COLLECTION
+}
+
 export function isNextExpr(obj: any): obj is NextExpr {
   return obj != null && obj.type === ExpressionType.NEXT
 }
@@ -36,6 +41,7 @@ export function isValueExpr(obj: any): obj is ValueExpr {
   if (isReferenceExpr(obj)) return true
   if (isFormatExpr(obj)) return true
   if (isPipelineExpr(obj)) return true
+  if (isCollectionExpr(obj)) return true
 
   // Check for function types
   if (obj != null && typeof obj === 'object' && 'type' in obj) {
@@ -66,6 +72,7 @@ export function isExpression(node: any): boolean {
     isFormatExpr(node) ||
     isPipelineExpr(node) ||
     isConditionalExpr(node) ||
+    isCollectionExpr(node) ||
     isPredicateExpr(node) ||
     isFunctionExpr(node) ||
     isValidationExpr(node) ||

--- a/packages/form-engine/src/form/typeguards/structures.ts
+++ b/packages/form-engine/src/form/typeguards/structures.ts
@@ -1,6 +1,5 @@
 import {
   BlockDefinition,
-  CollectionBlockDefinition,
   CompositeBlockDefinition,
   FieldBlockDefinition,
   JourneyDefinition,
@@ -22,10 +21,6 @@ export function isBlockDefinition(obj: any): obj is BlockDefinition {
 
 export function isFieldBlockDefinition(obj: any): obj is FieldBlockDefinition {
   return isBlockDefinition(obj) && 'code' in obj
-}
-
-export function isCollectionBlockDefinition(obj: any): obj is CollectionBlockDefinition<any> {
-  return isBlockDefinition(obj) && 'collectionContext' in obj
 }
 
 export function isCompositeBlockDefinition(obj: any): obj is CompositeBlockDefinition<any> {

--- a/packages/form-engine/src/form/types/enums.ts
+++ b/packages/form-engine/src/form/types/enums.ts
@@ -17,6 +17,7 @@ export enum ExpressionType {
   PIPELINE = 'ExpressionType.Pipeline',
   NEXT = 'ExpressionType.Next',
   VALIDATION = 'ExpressionType.Validation',
+  COLLECTION = 'ExpressionType.Collection',
 }
 
 export enum LogicType {

--- a/packages/form-engine/src/form/types/expressions.type.ts
+++ b/packages/form-engine/src/form/types/expressions.type.ts
@@ -228,6 +228,54 @@ export interface EffectFunctionExpr<A extends ValueExpr[] = ValueExpr[]> extends
 }
 
 /**
+ * Represents a collection expression that iterates over data to produce repeated templates.
+ * Collections allow dynamic generation of form elements based on arrays of data.
+ *
+ * @example
+ * // Iterate over addresses to create address fields
+ * {
+ *   type: 'ExpressionType.Collection',
+ *   collection: { type: 'ExpressionType.Reference', path: ['answers', 'addresses'] },
+ *   template: [
+ *     {
+ *       type: 'StructureType.Block',
+ *       variant: 'text',
+ *       code: { type: 'ExpressionType.Format', text: 'address_%1_line1', args: [{ type: 'ExpressionType.Reference', path: ['@item', 'id'] }] }
+ *     }
+ *   ]
+ * }
+ *
+ * @example
+ * // Collection with fallback when empty
+ * {
+ *   type: 'ExpressionType.Collection',
+ *   collection: { type: 'ExpressionType.Reference', path: ['data', 'items'] },
+ *   template: [...],
+ *   fallback: [{ type: 'StructureType.Block', variant: 'html', content: 'No items found' }]
+ * }
+ */
+export interface CollectionExpr<T = any> {
+  type: ExpressionType.COLLECTION
+
+  /**
+   * The data source to iterate over.
+   * Can be a reference expression or a static array.
+   */
+  collection: ValueExpr | any[]
+
+  /**
+   * Template blocks to render for each item in the collection.
+   * The template is repeated once per item with @item references resolved.
+   */
+  template: T[]
+
+  /**
+   * Optional fallback blocks to render when the collection is empty.
+   */
+  fallback?: T[]
+}
+
+/**
  * Represents any expression that evaluates to a value.
  * This is the base type for all expressions in the form system.
  */
@@ -236,6 +284,7 @@ export type ValueExpr =
   | FormatExpr
   | TransformerFunctionExpr
   | PipelineExpr
+  | CollectionExpr
   | ValueExpr[]
   | string
   | number

--- a/packages/form-engine/src/form/types/expressions.type.ts
+++ b/packages/form-engine/src/form/types/expressions.type.ts
@@ -261,7 +261,7 @@ export interface CollectionExpr<T = any> {
    * The data source to iterate over.
    * Can be a reference expression or a static array.
    */
-  collection: ValueExpr | any[]
+  collection: ReferenceExpr | PipelineExpr | any[]
 
   /**
    * Template blocks to render for each item in the collection.

--- a/packages/form-engine/src/form/types/structures.type.ts
+++ b/packages/form-engine/src/form/types/structures.type.ts
@@ -27,34 +27,6 @@ export interface BlockDefinition {
 }
 
 /**
- * Configuration options for collection-based blocks.
- * Defines the data source for iterating over collections.
- */
-export interface CollectionOptions {
-  /** The collection source - can be a reference, pipeline, or static array */
-  collection: ReferenceExpr | PipelineExpr | string[] | number[] | object[]
-}
-
-/**
- * Block definition for collection/repeater blocks.
- * Renders template blocks for each item in a collection.
- * @template T - The type of blocks used in the template
- */
-export interface CollectionBlockDefinition<T = BlockDefinition> extends BlockDefinition {
-  /** Template blocks to render for each collection item */
-  template: T[]
-
-  /** Configuration for the collection data source */
-  collectionContext: CollectionOptions
-
-  /**
-   * @internal - This property is set by the engine at runtime.
-   * DO NOT set this manually in your definitions.
-   */
-  blocks?: never
-}
-
-/**
  * Block definition for composite blocks that contain other blocks.
  * Used for grouping and layout purposes.
  * @template B - The type of child blocks

--- a/packages/form-engine/src/registry/components/core/collection-block/collectionBlock.test.ts
+++ b/packages/form-engine/src/registry/components/core/collection-block/collectionBlock.test.ts
@@ -1,14 +1,14 @@
 import { collectionBlock, EvaluatedCollectionBlock } from './collectionBlock'
-import { StructureType } from '../../../../form/types/enums'
+import { ExpressionType, StructureType } from '../../../../form/types/enums'
 import { RenderedBlock } from '../../../../form/types/structures.type'
+import { ASTTestFactory } from '../../../../test-utils/ASTTestFactory'
 
 describe('collectionBlock component', () => {
   const mockEvaluatedBlock = (overrides?: Partial<EvaluatedCollectionBlock>): EvaluatedCollectionBlock =>
     ({
       type: StructureType.BLOCK,
       variant: 'collection-block',
-      template: [],
-      collectionContext: { collection: [] },
+      collection: ASTTestFactory.expression(ExpressionType.COLLECTION).withCollection([]).withTemplate([]),
       ...overrides,
     }) as EvaluatedCollectionBlock
 

--- a/packages/form-engine/src/registry/components/core/collection-block/collectionBlock.ts
+++ b/packages/form-engine/src/registry/components/core/collection-block/collectionBlock.ts
@@ -1,20 +1,22 @@
 import { buildComponent } from '@form-engine/registry/utils/buildComponent'
+import { CollectionExpr } from '@form-engine/form/types/expressions.type'
 import {
   BlockDefinition,
-  CollectionBlockDefinition,
   ConditionalString,
   EvaluatedBlock,
   RenderedBlock,
 } from '../../../../form/types/structures.type'
 
+// TODO: I need to come back to this once I know more about how the collections are unpacked
+//  at runtime. Just ignore if this is dumb for now.
+
 /**
  * Collection block component for rendering repeated blocks based on a collection.
  */
-export interface CollectionBlock<T = BlockDefinition> extends CollectionBlockDefinition<T> {
+export interface CollectionBlock<T = BlockDefinition> extends BlockDefinition {
   variant: 'collection-block'
 
-  /** Optional fallback block to render when collection is empty */
-  fallbackTemplate?: T
+  collection: CollectionExpr<T>
 
   /** Additional CSS classes to apply to wrapper div (optional) */
   classes?: ConditionalString

--- a/packages/form-engine/src/test-utils/ASTTestFactory.ts
+++ b/packages/form-engine/src/test-utils/ASTTestFactory.ts
@@ -9,6 +9,7 @@ import {
 } from '@form-engine/core/types/expressions.type'
 import { BlockASTNode, JourneyASTNode, StepASTNode } from '@form-engine/core/types/structures.type'
 import { ASTNodeType } from '@form-engine/core/types/enums'
+import { PipelineExpr, ReferenceExpr } from '@form-engine/form/types/expressions.type'
 
 type PredicateBuilderConfig = {
   subject?: ExpressionASTNode
@@ -18,7 +19,7 @@ type PredicateBuilderConfig = {
   operand?: ExpressionASTNode
 }
 
-type BlockType = 'basic' | 'field' | 'collection' | 'composite'
+type BlockType = 'basic' | 'field' | 'composite'
 
 /**
  * Test data factory for creating AST nodes with fluent builders and automatic ID generation.
@@ -201,26 +202,6 @@ export class ASTTestFactory {
                     .build(),
                 ),
             ),
-        )
-        .build()
-    },
-
-    /**
-     * Form with collection blocks
-     */
-    withCollection: (): JourneyASTNode => {
-      const itemTemplate = ASTTestFactory.block('Composite', 'composite')
-        .withProperty('blocks', [
-          ASTTestFactory.block('TextInput', 'field').withCode('street').withLabel('Street').build(),
-          ASTTestFactory.block('TextInput', 'field').withCode('city').withLabel('City').build(),
-        ])
-        .build()
-
-      return ASTTestFactory.journey()
-        .withStep(step =>
-          step.withBlock('Collection', 'collection', block =>
-            block.withCode('addresses').withLabel('Addresses').withProperty('itemTemplate', itemTemplate),
-          ),
         )
         .build()
     },
@@ -592,6 +573,21 @@ export class ExpressionBuilder<T = ExpressionASTNode> {
 
   withSteps(steps: any[]): this {
     this.properties.set('steps', steps)
+    return this
+  }
+
+  withCollection(collection: ReferenceExpr | PipelineExpr | any[]): this {
+    this.properties.set('collection', collection)
+    return this
+  }
+
+  withTemplate(nodes: ASTNode[]): this {
+    this.properties.set('template', nodes)
+    return this
+  }
+
+  withFallback(node: ASTNode): this {
+    this.properties.set('fallback', node)
     return this
   }
 


### PR DESCRIPTION
- Get rid of the `CollectionBlockDefinition` and go with something more freeform
- Added `CollectionExpr` which allows you to define Collections and their templates/fallbacks through an expression
- Reason for change is that it was 
  - Hardcoded to blocks, 
  - Is more flexible (now a developer could have a component representing multiple collections, 
  - Works better for dependency analysis/thunks