### PR TITLE
SP2-2068: Announce inline validation errors (accessibility)

### DIFF
--- a/integration_tests/specs/sentencePlan/createGoal.spec.ts
+++ b/integration_tests/specs/sentencePlan/createGoal.spec.ts
@@ -370,6 +370,72 @@ test.describe('Create Goal Journey', () => {
       await createGoalPage.errorSummary.getByRole('link').first().click()
       await expect(createGoalPage.targetDateOptions.first()).toBeFocused()
     })
+
+    test(`related areas of need checkboxes' inputs have individual aria-describedby attribute for inline errors`, async ({
+      page,
+      createSession,
+    }) => {
+      const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await navigateToSentencePlan(page, handoverLink)
+      await page.getByRole('button', { name: 'Create goal' }).click()
+
+      const createGoalPage = await CreateGoalPage.verifyOnPage(page)
+      await createGoalPage.selectIsRelated(true)
+
+      // click add steps to trigger error:
+      await createGoalPage.clickAddSteps()
+
+      const checkboxAriaValues = await page
+        .locator('fieldset input[type="checkbox"]')
+        .evaluateAll(els => els.map(el => el.getAttribute('aria-describedby')))
+
+      expect(checkboxAriaValues.length).toBeGreaterThan(0)
+      checkboxAriaValues.forEach(value => {
+        expect(value).toBe('related_areas_of_need-error')
+      })
+    })
+
+    test(`related areas of need radio buttons' inputs have individual aria-describedby attribute for inline errors`, async ({
+      page,
+      createSession,
+    }) => {
+      const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await navigateToSentencePlan(page, handoverLink)
+      await page.getByRole('button', { name: 'Create goal' }).click()
+
+      const createGoalPage = await CreateGoalPage.verifyOnPage(page)
+
+      // click add steps to trigger error:
+      await createGoalPage.clickAddSteps()
+
+      const radioInputAriaDescribedByValues = await page
+        .locator('fieldset input[id="is_related_to_other_areas"]')
+        .evaluateAll(radioButtonInputElements =>
+          radioButtonInputElements.map(element => element.getAttribute('aria-describedby')),
+        )
+
+      expect(radioInputAriaDescribedByValues.length).toBeGreaterThan(0)
+      radioInputAriaDescribedByValues.forEach(value => {
+        expect(value).toBe('is_related_to_other_areas-error')
+      })
+    })
+
+    test(`inline error id is referenced in aria-describedby attribute for goal title input`, async ({
+      page,
+      createSession,
+    }) => {
+      const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await navigateToSentencePlan(page, handoverLink)
+      await page.getByRole('button', { name: 'Create goal' }).click()
+
+      const createGoalPage = await CreateGoalPage.verifyOnPage(page)
+
+      // click add steps to trigger error:
+      await createGoalPage.clickAddSteps()
+
+      const goalTitleInput = createGoalPage.goalTitleInput
+      await expect(goalTitleInput).toHaveAttribute('aria-describedby', /goal_title-error/)
+    })
   })
 
   test.describe('Different Areas of Need', () => {

--- a/packages/form-engine-govuk-components/src/components/checkbox-input/govukCheckboxInput.ts
+++ b/packages/form-engine-govuk-components/src/components/checkbox-input/govukCheckboxInput.ts
@@ -296,7 +296,8 @@ export const govukCheckboxInput = buildNunjucksComponent<GovUKCheckboxInput>(
   (block, nunjucksEnv) => {
     // At render time, items has been evaluated (Collection expressions resolved to arrays)
     const evaluatedItems = block.items as EvaluatedBlock<GovUKCheckboxInputItem | GovUKCheckboxInputDivider>[]
-    const items = evaluatedItems.map(option => makeOption(option, block.value))
+    const errorId = block.errors?.length ? `${block.idPrefix ?? block.code}-error` : undefined
+    const items = evaluatedItems.map(option => makeOption(option, block.value, errorId))
     const fieldset = block.fieldset ?? (block.label ? { legend: { text: block.label } } : undefined)
 
     const params = {
@@ -329,7 +330,11 @@ const getConditionalContent = (block: RenderedBlock | RenderedBlock[] | undefine
   return { html: block.html }
 }
 
-const makeOption = (option: EvaluatedBlock<GovUKCheckboxInputItem | GovUKCheckboxInputDivider>, blockValue?: any) => {
+const makeOption = (
+  option: EvaluatedBlock<GovUKCheckboxInputItem | GovUKCheckboxInputDivider>,
+  blockValue?: any,
+  errorId?: string,
+) => {
   if (isCheckboxDivider(option)) {
     return {
       divider: option.divider,
@@ -344,6 +349,15 @@ const makeOption = (option: EvaluatedBlock<GovUKCheckboxInputItem | GovUKCheckbo
     isChecked = blockValue.includes(option.value)
   }
 
+  const hasItemHint = Boolean(option.hint)
+  const attributes =
+    !hasItemHint && errorId
+      ? {
+          ...option.attributes,
+          'aria-describedby': [option.attributes?.['aria-describedby'], errorId].filter(Boolean).join(' '),
+        }
+      : option.attributes
+
   return {
     value: option.value,
     text: option.text,
@@ -354,7 +368,7 @@ const makeOption = (option: EvaluatedBlock<GovUKCheckboxInputItem | GovUKCheckbo
     conditional: getConditionalContent(option.block),
     disabled: option.disabled,
     behaviour: option.behaviour,
-    attributes: option.attributes,
+    attributes,
     label: option.label,
   }
 }

--- a/packages/form-engine-govuk-components/src/components/radio-input/govukRadioInput.ts
+++ b/packages/form-engine-govuk-components/src/components/radio-input/govukRadioInput.ts
@@ -248,7 +248,8 @@ interface GovUKRadioInputDivider {
 }
 
 export const govukRadioInput = buildNunjucksComponent<GovUKRadioInput>('govukRadioInput', (block, nunjucksEnv) => {
-  const items = block.items.map(option => makeOption(option, block.value as string))
+  const errorId = block.errors?.length ? `${block.idPrefix ?? block.code}-error` : undefined
+  const items = block.items.map(option => makeOption(option, block.value as string, errorId))
 
   const params = {
     fieldset: block.fieldset || {
@@ -284,12 +285,25 @@ const getConditionalContent = (block: RenderedBlock | RenderedBlock[] | undefine
   return { html: block.html }
 }
 
-const makeOption = (option: EvaluatedBlock<GovUKRadioInputItem | GovUKRadioInputDivider>, checkedValue: string) => {
+const makeOption = (
+  option: EvaluatedBlock<GovUKRadioInputItem | GovUKRadioInputDivider>,
+  checkedValue: string,
+  errorId?: string,
+) => {
   if (isRadioDivider(option)) {
     return {
       divider: option.divider,
     }
   }
+
+  const hasItemHint = Boolean(option.hint)
+  const attributes =
+    !hasItemHint && errorId
+      ? {
+          ...option.attributes,
+          'aria-describedby': [option.attributes?.['aria-describedby'], errorId].filter(Boolean).join(' '),
+        }
+      : option.attributes
 
   return {
     value: option.value,
@@ -300,7 +314,7 @@ const makeOption = (option: EvaluatedBlock<GovUKRadioInputItem | GovUKRadioInput
     checked: checkedValue === option.value || (option.checked ?? false),
     conditional: getConditionalContent(option.block),
     disabled: option.disabled,
-    attributes: option.attributes,
+    attributes,
   }
 }
 

--- a/server/forms/sentence-plan/components/accessible-autocomplete/accessible-autocomplete.mjs
+++ b/server/forms/sentence-plan/components/accessible-autocomplete/accessible-autocomplete.mjs
@@ -1,27 +1,31 @@
-import accessibleAutocomplete from 'accessible-autocomplete'
+import accessibleAutocomplete from "accessible-autocomplete";
 
 class AccessibleAutocomplete extends HTMLElement {
   constructor() {
-    super()
+    super();
     if (this.dataset.initialized) {
-      return
+      return;
     }
 
-    this.dataset.initialized = 'true'
+    this.dataset.initialized = "true";
 
-    const input = this.querySelector('input')
+    const input = this.querySelector("input");
 
     if (!input) {
-      console.warn('accessible-autocomplete: no input found', this)
-      return
+      console.warn("accessible-autocomplete: no input found", this);
+      return;
     }
 
-    const source = this.getSource()
-    const defaultValue = this.dataset.autocompleteDefaultValue ?? input.value
-    const inputId = input.id
-    const inputName = input.name
+    const source = this.getSource();
+    const defaultValue = this.dataset.autocompleteDefaultValue ?? input.value;
+    const inputId = input.id;
+    const inputName = input.name;
+    const errorId = `${inputId}-error`;
+    const originalDescribedByErrorIds = (input.getAttribute("aria-describedby") ?? "")
+      .split(" ")
+      .filter((id) => id === errorId);
 
-    input.remove()
+    input.remove();
 
     accessibleAutocomplete({
       element: this,
@@ -29,56 +33,84 @@ class AccessibleAutocomplete extends HTMLElement {
       name: inputName,
       source,
       defaultValue,
-      minLength: parseInt(this.dataset.autocompleteMinLength ?? '2', 10),
-      showNoOptionsFound: this.dataset.autocompleteShowNoOptions === 'true',
+      minLength: parseInt(this.dataset.autocompleteMinLength ?? "2", 10),
+      showNoOptionsFound: this.dataset.autocompleteShowNoOptions === "true",
       menuClasses: this.dataset.autocompleteMenuClasses ?? null,
       inputClasses: this.dataset.autocompleteInputClasses ?? null,
       hintClasses: this.dataset.autocompleteHintClasses ?? null,
-      autoselect: this.dataset.autocompleteAutoselect === 'true',
-      confirmOnBlur: this.dataset.autocompleteConfirmOnBlur !== 'false',
-      displayMenu: this.dataset.autocompleteDisplayMenu ?? 'inline',
-      showAllValues: this.dataset.autocompleteShowAllValues === 'true',
+      autoselect: this.dataset.autocompleteAutoselect === "true",
+      confirmOnBlur: this.dataset.autocompleteConfirmOnBlur !== "false",
+      displayMenu: this.dataset.autocompleteDisplayMenu ?? "inline",
+      showAllValues: this.dataset.autocompleteShowAllValues === "true",
       menuAttributes: this.dataset.autocompleteMenuAttributes
         ? JSON.parse(this.dataset.autocompleteMenuAttributes)
         : {},
-    })
+    });
+    this.preserveDescribedBy(originalDescribedByErrorIds);
+  }
+
+  preserveDescribedBy(originalIds) {
+    if (originalIds.length === 0) {
+      return;
+    }
+
+    const input = this.querySelector("input");
+
+    if (!input) {
+      return;
+    }
+
+    const merge = () => {
+      const current = (input.getAttribute("aria-describedby") ?? "").split(" ").filter(Boolean);
+      const merged = [...new Set([...current, ...originalIds])].join(" ");
+
+      if (merged !== input.getAttribute("aria-describedby")) {
+        observer.disconnect();
+        input.setAttribute("aria-describedby", merged);
+        observer.observe(input, { attributes: true, attributeFilter: ["aria-describedby"] });
+      }
+    };
+
+    const observer = new MutationObserver(merge);
+    observer.observe(input, { attributes: true, attributeFilter: ["aria-describedby"] });
+    merge();
   }
 
   getSource() {
-    const sourceId = this.dataset.autocompleteSource
+    const sourceId = this.dataset.autocompleteSource;
 
     if (!sourceId) {
-      return []
+      return [];
     }
 
-    const data = this.getData(sourceId)
-    const keyFromSelector = this.dataset.autocompleteSourceKeyFrom
+    const data = this.getData(sourceId);
+    const keyFromSelector = this.dataset.autocompleteSourceKeyFrom;
 
-    if (keyFromSelector && typeof data === 'object' && !Array.isArray(data)) {
-      const keyElement = document.querySelector(keyFromSelector)
-      const key = keyElement?.value ?? ''
+    if (keyFromSelector && typeof data === "object" && !Array.isArray(data)) {
+      const keyElement = document.querySelector(keyFromSelector);
+      const key = keyElement?.value ?? "";
 
-      return data[key] ?? []
+      return data[key] ?? [];
     }
 
-    return Array.isArray(data) ? data : []
+    return Array.isArray(data) ? data : [];
   }
 
   getData(sourceId) {
-    const el = document.getElementById(sourceId)
+    const el = document.getElementById(sourceId);
 
     if (!el) {
-      console.warn(`accessible-autocomplete: data element #${sourceId} not found`)
-      return {}
+      console.warn(`accessible-autocomplete: data element #${sourceId} not found`);
+      return {};
     }
 
     try {
-      return JSON.parse(el.textContent || '{}')
+      return JSON.parse(el.textContent || "{}");
     } catch (e) {
-      console.error(`accessible-autocomplete: failed to parse JSON from #${sourceId}`, e)
-      return {}
+      console.error(`accessible-autocomplete: failed to parse JSON from #${sourceId}`, e);
+      return {};
     }
   }
 }
 
-customElements.define('accessible-autocomplete-wrapper', AccessibleAutocomplete)
+customElements.define("accessible-autocomplete-wrapper", AccessibleAutocomplete);

--- a/server/forms/training-session-launcher/index.ts
+++ b/server/forms/training-session-launcher/index.ts
@@ -4,7 +4,7 @@ import { createTrainingSessionLauncherEffectsRegistry } from './effects'
 import { trainingSessionLauncherComponents } from './components'
 import { TrainingSessionLauncherTransformersRegistry } from './transformers'
 import { TrainingSessionLauncherEffectsDeps } from './effects/types'
-import config from "../../config";
+import config from '../../config'
 
 /**
  * Training Session Launcher Form Package


### PR DESCRIPTION
## PROBLEM
See ticket [SP2-2068](https://dsdmoj.atlassian.net/browse/SP2-2068) for details.
> Inline errors were not announced by the screen reader when focusing on an input across multiple components.

### Affected:

- govukCheckboxInput
>  when a checkbox group has a validation error, the GOV.UK Design System renders an error message element with an id like `related_areas_of_need-error`, but the individual `<input type="checkbox">` elements don't reference that id via `aria-describedby`, screen readers therefore don't announce the error when a user focuses a checkbox

- govUkRadioInput
>  same issue as above

- accessibleAutocomplete
> the accessible-autocomplete library replaces the original <input> element with its own dynamically created input
> when it does this, the original aria-describedby attribute (which included the error id) is lost, so screen readers no longer announce the inline error

## FIX

### Checkboxes & Radios: 
> Added the error message id to `aria-describedby` on each input element when validation errors are present.
This ensures screen readers announce the error when a user focuses the input, not just when they navigate the parent fieldset. Items with hints are skipped to avoid conflicting with the govuk template's own aria-describedby wiring. 

### Accessible Autocomplete:
> Captured the error id before the original input is removed and used a MutationObserver to merge it
   back into the new input's aria-describedby whenever the library updates it.

### Added integration tests covering all three components to verify the error id is present on focused inputs after validation failure.  