### PR TITLE
SP2-2081: Fix update agreement link placement on Plan History page

### DIFF
--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
@@ -171,6 +171,61 @@ test.describe('Plan History - Agreements', () => {
     })
   })
 
+  test.describe('Update agreement link placement', () => {
+    test('should display update agreement link within the agreement section when status is COULD_NOT_ANSWER', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({
+          title: 'Find stable accommodation',
+          areaOfNeed: 'accommodation',
+          status: 'ACTIVE',
+          steps: [{ actor: 'probation_practitioner', description: 'Contact housing services' }],
+        })
+        .withPlanAgreements([
+          {
+            status: 'COULD_NOT_ANSWER',
+            createdBy: 'Test Practitioner',
+            detailsCouldNotAnswer: 'Person was not available to discuss the plan',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      await page.goto(handoverLink)
+      await handlePrivacyScreenIfPresent(page)
+      await page.getByRole('link', { name: /Plan history/i }).click()
+      const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
+      await expect(planHistoryPage.updateAgreementLink).toBeVisible()
+
+      await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
+        - paragraph: View all updates and changes made to this plan.
+        - separator
+        - paragraph:
+          - strong: Plan created
+          - text: /Test Practitioner/
+        - paragraph: /could not agree/
+        - paragraph: Person was not available to discuss the plan
+        - paragraph:
+          - link /Update .+ agreement/
+        - separator
+        - paragraph:
+          - strong: Goal created
+          - text: /E2E Test/
+        - paragraph:
+          - strong: Find stable accommodation
+        - paragraph:
+          - link "View goal"
+        - paragraph:
+          - link /.+ Back to top/
+      `)
+    })
+  })
+
   test.describe('Read-only access', () => {
     test('hides update agreement link in read-only mode even when status is COULD_NOT_ANSWER', async ({
       page,

--- a/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.navigation.spec.ts
+++ b/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.navigation.spec.ts
@@ -17,12 +17,7 @@ test.describe('Update agree plan - Navigation', () => {
       await sentencePlanBuilder
         .extend(sentencePlanId)
         .withGoals(currentGoalsWithCompletedSteps(1))
-        .withPlanAgreements([
-          {
-            status: 'COULD_NOT_ANSWER',
-            detailsCouldNotAnswer: 'Person was not available to discuss the plan',
-          },
-        ])
+        .withAgreementStatus('AGREED')
         .save()
 
       await navigateToSentencePlan(page, handoverLink)
@@ -38,7 +33,12 @@ test.describe('Update agree plan - Navigation', () => {
       await sentencePlanBuilder
         .extend(sentencePlanId)
         .withGoals(currentGoalsWithCompletedSteps(1))
-        .withAgreementStatus('COULD_NOT_ANSWER')
+        .withPlanAgreements([
+          {
+            status: 'COULD_NOT_ANSWER',
+            detailsCouldNotAnswer: 'Person was not available to discuss the plan',
+          },
+        ])
         .save()
       await navigateToSentencePlan(page, handoverLink)
     })

--- a/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.navigation.spec.ts
+++ b/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.navigation.spec.ts
@@ -17,7 +17,12 @@ test.describe('Update agree plan - Navigation', () => {
       await sentencePlanBuilder
         .extend(sentencePlanId)
         .withGoals(currentGoalsWithCompletedSteps(1))
-        .withAgreementStatus('AGREED')
+        .withPlanAgreements([
+          {
+            status: 'COULD_NOT_ANSWER',
+            detailsCouldNotAnswer: 'Person was not available to discuss the plan',
+          },
+        ])
         .save()
 
       await navigateToSentencePlan(page, handoverLink)

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -1,4 +1,4 @@
-import { Data, Format, Item, match, or, when } from '@form-engine/form/builders'
+import { and, Data, Format, Item, match, when } from '@form-engine/form/builders'
 import { Iterator } from '@form-engine/form/builders/IteratorBuilder'
 import { HtmlBlock } from '@form-engine/registry/components/html'
 import { CollectionBlock } from '@form-engine/registry/components/collectionBlock'
@@ -9,6 +9,14 @@ import { GovUKSectionBreak } from '@form-engine-govuk-components/wrappers/govukS
 import { CaseData } from '../../../../constants'
 
 const isReadOnly = Data('sessionDetails.planAccessMode').match(Condition.Equals('READ_ONLY'))
+const isEditModeAccess = Data('sessionDetails.planAccessMode').match(Condition.Equals('READ_WRITE'))
+
+const updateAgreementLink = Format(
+  '<p class="govuk-body"><a href="update-agree-plan" class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print">Update %1 agreement</a></p>',
+  CaseData.ForenamePossessive,
+)
+
+const isCouldNotAnswerAgreementStatus = Data('latestAgreementStatus').match(Condition.Equals('COULD_NOT_ANSWER'))
 
 export const subtitleText = GovUKBody({ text: 'View all updates and changes made to this plan.' })
 
@@ -49,7 +57,7 @@ const agreementEntryContent = Format(
       Format('%1 did not agree to this plan.', CaseData.Forename),
     )
     .otherwise(Format('%1 could not agree to this plan.', CaseData.Forename)),
-  // %6: Reason details and optional notes combined in a single paragraph
+  // %6: Reason details and optional notes combined in a single paragraph (link to update the agreement is in a separate <p>)
   when(Item().path('detailsNo').match(Condition.IsRequired()))
     .then(
       when(Item().path('notes').match(Condition.IsRequired()))
@@ -68,15 +76,27 @@ const agreementEntryContent = Format(
           when(Item().path('notes').match(Condition.IsRequired()))
             .then(
               Format(
-                '<p class="govuk-body">%1<br>%2</p>',
+                `<div class="govuk-!-margin-bottom-6">
+                <p class="govuk-body">%1<br>%2</p>
+                %3
+                </div>`,
                 Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
                 Item().path('notes').pipe(Transformer.String.EscapeHtml()),
+                when(and(isEditModeAccess, isCouldNotAnswerAgreementStatus))
+                  .then(updateAgreementLink)
+                  .else(''),
               ),
             )
             .else(
               Format(
-                '<p class="govuk-body">%1</p>',
+                `<div class="govuk-!-margin-bottom-6">
+                <p class="govuk-body">%1</p>
+                %2
+                </div>`,
                 Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
+                when(and(isEditModeAccess, isCouldNotAnswerAgreementStatus))
+                  .then(updateAgreementLink)
+                  .else(''),
               ),
             ),
         )
@@ -296,17 +316,6 @@ export const agreementHistory = CollectionBlock({
         ),
       }),
     ),
-  ),
-})
-
-/**
- * Link to update the person's agreement - shown when latest status is COULD_NOT_ANSWER
- */
-export const updateAgreementLink = GovUKBody({
-  hidden: or(isReadOnly, Data('latestAgreementStatus').not.match(Condition.Equals('COULD_NOT_ANSWER'))),
-  text: Format(
-    '<a href="update-agree-plan" class="govuk-link govuk-link--no-visited-state govuk-!-display-none-print">Update %1\'s agreement</a>',
-    CaseData.Forename,
   ),
 })
 

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/step.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/step.ts
@@ -1,5 +1,5 @@
 import { accessTransition, step } from '@form-engine/form/builders'
-import { subtitleText, sectionBreak, agreementHistory, updateAgreementLink, backToTopLink } from './fields'
+import { subtitleText, sectionBreak, agreementHistory, backToTopLink } from './fields'
 import { AuditEvent, SentencePlanEffects } from '../../../../../../effects'
 import { isOasysAccess, redirectIfNotPostAgreement, redirectToPrivacyUnlessAccepted } from '../../../../guards'
 
@@ -15,7 +15,7 @@ export const planHistoryStep = step({
       },
     },
   },
-  blocks: [subtitleText, sectionBreak, agreementHistory, updateAgreementLink, backToTopLink],
+  blocks: [subtitleText, sectionBreak, agreementHistory, backToTopLink],
   onAccess: [
     redirectToPrivacyUnlessAccepted(),
     accessTransition({


### PR DESCRIPTION
## Problem
The link “Update [Name] agreement“ is displayed in the incorrect section under the “Plan History” when the `could not answer this question` option below is selected:

<img width="2054" height="1772" alt="image" src="https://github.com/user-attachments/assets/f4300d25-4d2d-40ee-b507-0089b46f8749" />

## Fix

<img width="930" height="798" alt="Screenshot 2026-04-14 at 16 59 09" src="https://github.com/user-attachments/assets/b4a3a786-fcd0-4a85-bc4c-7f0a21a238eb" />
