### PR TITLE
SP2-1749: Change steps adds plan history event

### DIFF
--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.updatedGoals.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.updatedGoals.spec.ts
@@ -3,6 +3,7 @@ import { test, TargetService } from '../../../support/fixtures'
 import PlanHistoryPage from '../../../pages/sentencePlan/planHistoryPage'
 import UpdateGoalAndStepsPage from '../../../pages/sentencePlan/updateGoalAndStepsPage'
 import PlanOverviewPage from '../../../pages/sentencePlan/planOverviewPage'
+import AddStepsPage from '../../../pages/sentencePlan/addStepsPage'
 import {
   checkAccessibility,
   handlePrivacyScreenIfPresent,
@@ -216,6 +217,52 @@ test.describe('Plan History - Updated Goals', () => {
       - paragraph:
         - strong: Reduce alcohol use
       - paragraph: Good progress being made with support group attendance.
+      - paragraph:
+        - link "View latest version":
+          - /url: /goal/
+    `)
+  })
+
+  test('shows goal updated entry after changing step details', async ({ page, createSession, sentencePlanBuilder }) => {
+    const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+    await sentencePlanBuilder
+      .extend(sentencePlanId)
+      .withGoal({
+        title: 'Find stable accommodation',
+        areaOfNeed: 'accommodation',
+        status: 'ACTIVE',
+        steps: [{ actor: 'probation_practitioner', description: 'Contact housing services', status: 'NOT_STARTED' }],
+      })
+      .withPlanAgreements([
+        {
+          status: 'AGREED',
+          createdBy: 'Test Practitioner',
+          dateOffset: -86400000,
+        },
+      ])
+      .save()
+
+    await navigateToSentencePlan(page, handoverLink)
+    const planOverviewPage = await PlanOverviewPage.verifyOnPage(page)
+
+    await planOverviewPage.clickUpdateGoal(0)
+    const updatePage = await UpdateGoalAndStepsPage.verifyOnPage(page)
+
+    await updatePage.clickAddOrChangeSteps()
+    const addStepsPage = await AddStepsPage.verifyOnPage(page)
+    await addStepsPage.enterStep(0, 'person_on_probation', 'Contact the housing officer')
+    await addStepsPage.clickSaveAndContinue()
+
+    await page.goto(sentencePlanV1URLs.PLAN_HISTORY)
+    const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
+
+    await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
+      - paragraph: View all updates and changes made to this plan.
+      - separator
+      - paragraph:
+        - strong: Goal updated
+      - paragraph:
+        - strong: Find stable accommodation
       - paragraph:
         - link "View latest version":
           - /url: /goal/

--- a/server/forms/sentence-plan/effects/steps/saveStepEditSession.test.ts
+++ b/server/forms/sentence-plan/effects/steps/saveStepEditSession.test.ts
@@ -1,0 +1,252 @@
+import { saveStepEditSession } from './saveStepEditSession'
+import type {
+  DerivedGoal,
+  SentencePlanContext,
+  SentencePlanEffectsDeps,
+  SentencePlanSession,
+  StepChanges,
+  StepSession,
+} from '../types'
+import type { User } from '../../../../interfaces/user'
+
+const user: User = {
+  id: 'user-1',
+  name: 'Fallback User',
+  authSource: 'HMPPS_AUTH',
+}
+
+const activeGoal = {
+  uuid: 'goal-1',
+  title: 'Find stable accommodation',
+  stepsCollectionUuid: 'steps-collection-1',
+} as DerivedGoal
+
+interface MockContextOptions {
+  session?: SentencePlanSession
+  answers?: Record<string, string>
+  data?: Record<string, unknown>
+}
+
+function createMockContext(options: MockContextOptions = {}) {
+  const session = options.session ?? {}
+  const answers = options.answers ?? {}
+  const data: Record<string, unknown> = {
+    assessmentUuid: 'assessment-1',
+    activeGoalUuid: activeGoal.uuid,
+    activeGoal,
+    activeGoalStepsOriginal: [] as StepSession[],
+    navigationReferrer: 'update-goal-steps',
+    ...options.data,
+  }
+
+  return {
+    getSession: jest.fn(() => session),
+    getState: jest.fn((key: string) => (key === 'user' ? user : undefined)),
+    getData: jest.fn((key: string) => data[key]),
+    getAnswer: jest.fn((key: string) => answers[key]),
+  } as unknown as SentencePlanContext
+}
+
+function createDeps() {
+  return {
+    api: {
+      executeCommand: jest.fn().mockResolvedValue({ collectionUuid: 'created-steps-collection' }),
+      executeCommands: jest.fn().mockResolvedValue([]),
+    },
+  } as unknown as SentencePlanEffectsDeps
+}
+
+function createStepChanges(overrides: Partial<StepChanges>): StepChanges {
+  return {
+    steps: [],
+    toCreate: [],
+    toUpdate: [],
+    toDelete: [],
+    collectionUuid: activeGoal.stepsCollectionUuid,
+    ...overrides,
+  }
+}
+
+function createStep(overrides: Partial<StepSession>): StepSession {
+  return {
+    id: 'step-1',
+    actor: 'probation_practitioner',
+    description: 'Contact housing services',
+    ...overrides,
+  }
+}
+
+function getExecutedCommands(deps: SentencePlanEffectsDeps) {
+  return (deps.api.executeCommands as jest.Mock).mock.calls[0] ?? []
+}
+
+describe('saveStepEditSession', () => {
+  it('should add a GOAL_UPDATED timeline event when an existing step is changed', async () => {
+    const deps = createDeps()
+    const session: SentencePlanSession = {
+      practitionerDetails: { identifier: 'user-1', displayName: 'Jane Smith', authSource: 'HMPPS_AUTH' },
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [createStep({ id: 'step-1' })],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      data: {
+        activeGoalStepsOriginal: [
+          createStep({
+            id: 'step-1',
+            actor: 'probation_practitioner',
+            description: 'Contact housing services',
+          }),
+        ],
+      },
+      answers: {
+        step_actor_0: 'person_on_probation',
+        step_description_0: 'Contact the housing officer',
+      },
+    })
+
+    await saveStepEditSession(deps)(context)
+
+    const commands = getExecutedCommands(deps)
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        type: 'UpdateCollectionItemPropertiesCommand',
+        collectionItemUuid: activeGoal.uuid,
+        timeline: {
+          type: 'GOAL_UPDATED',
+          data: {
+            goalUuid: activeGoal.uuid,
+            goalTitle: activeGoal.title,
+            updatedBy: 'Jane Smith',
+          },
+        },
+      }),
+    )
+  })
+
+  it('should add a GOAL_UPDATED timeline event when a new step is added to an existing goal', async () => {
+    const deps = createDeps()
+    const newStep = createStep({ id: 'step-new', actor: '', description: '' })
+    const session: SentencePlanSession = {
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [newStep],
+          toCreate: [newStep.id],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      answers: {
+        step_actor_0: 'probation_practitioner',
+        step_description_0: 'Book an appointment',
+      },
+    })
+
+    await saveStepEditSession(deps)(context)
+
+    const commands = getExecutedCommands(deps)
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        type: 'UpdateCollectionItemPropertiesCommand',
+        collectionItemUuid: activeGoal.uuid,
+        timeline: expect.objectContaining({ type: 'GOAL_UPDATED' }),
+      }),
+    )
+  })
+
+  it('should add a GOAL_UPDATED timeline event when a step is removed', async () => {
+    const deps = createDeps()
+    const session: SentencePlanSession = {
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [createStep({ id: 'step-2' })],
+          toDelete: ['step-1'],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      data: {
+        activeGoalStepsOriginal: [createStep({ id: 'step-1' }), createStep({ id: 'step-2' })],
+      },
+      answers: {
+        step_actor_0: 'probation_practitioner',
+        step_description_0: 'Contact housing services',
+      },
+    })
+
+    await saveStepEditSession(deps)(context)
+
+    const commands = getExecutedCommands(deps)
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        type: 'UpdateCollectionItemPropertiesCommand',
+        collectionItemUuid: activeGoal.uuid,
+        timeline: expect.objectContaining({ type: 'GOAL_UPDATED' }),
+      }),
+    )
+  })
+
+  it('should not add a GOAL_UPDATED timeline event when step values are unchanged', async () => {
+    const deps = createDeps()
+    const unchangedStep = createStep({ id: 'step-1' })
+    const session: SentencePlanSession = {
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [unchangedStep],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      data: { activeGoalStepsOriginal: [unchangedStep] },
+      answers: {
+        step_actor_0: unchangedStep.actor,
+        step_description_0: unchangedStep.description,
+      },
+    })
+
+    await saveStepEditSession(deps)(context)
+
+    const commands = getExecutedCommands(deps)
+    expect(commands).not.toContainEqual(
+      expect.objectContaining({
+        timeline: expect.objectContaining({ type: 'GOAL_UPDATED' }),
+      }),
+    )
+  })
+
+  it('should not add a GOAL_UPDATED timeline event when saving steps for a newly-created goal', async () => {
+    const deps = createDeps()
+    const newStep = createStep({ id: 'step-new', actor: '', description: '' })
+    const session: SentencePlanSession = {
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [newStep],
+          toCreate: [newStep.id],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      data: { navigationReferrer: 'add-goal' },
+      answers: {
+        step_actor_0: 'probation_practitioner',
+        step_description_0: 'Book an appointment',
+      },
+    })
+
+    await saveStepEditSession(deps)(context)
+
+    const commands = getExecutedCommands(deps)
+    expect(commands).not.toContainEqual(
+      expect.objectContaining({
+        timeline: expect.objectContaining({ type: 'GOAL_UPDATED' }),
+      }),
+    )
+  })
+})

--- a/server/forms/sentence-plan/effects/steps/saveStepEditSession.ts
+++ b/server/forms/sentence-plan/effects/steps/saveStepEditSession.ts
@@ -1,7 +1,7 @@
 import { wrapAll } from '../../../../data/aap-api/wrappers'
 import { SentencePlanContext, SentencePlanEffectsDeps, StepAnswers, StepChangesStorage, StepProperties } from '../types'
 import { Commands } from '../../../../interfaces/aap-api/command'
-import { getRequiredEffectContext } from '../goals/goalUtils'
+import { getPractitionerName, getRequiredEffectContext } from '../goals/goalUtils'
 
 /**
  * Save the step edit session to the API
@@ -10,6 +10,7 @@ export const saveStepEditSession = (deps: SentencePlanEffectsDeps) => async (con
   const { user, assessmentUuid } = getRequiredEffectContext(context, 'saveStepEditSession')
   const session = context.getSession()
   const activeGoalUuid = context.getData('activeGoalUuid')
+  const activeGoal = context.getData('activeGoal')
 
   const storage: StepChangesStorage = session?.stepChanges ?? {}
   const { steps, toCreate, toDelete, collectionUuid } = storage[activeGoalUuid] ?? {
@@ -48,6 +49,9 @@ export const saveStepEditSession = (deps: SentencePlanEffectsDeps) => async (con
 
     return current.actor !== original?.actor || current.description !== original?.description
   })
+
+  const hasStepChanges = newSteps.length > 0 || modifiedSteps.length > 0 || toDelete.length > 0
+  const isCreatingGoal = context.getData('navigationReferrer') === 'add-goal'
 
   // Find or create STEPS collection if we have new steps to add
   let stepsCollectionUuid = collectionUuid
@@ -121,6 +125,27 @@ export const saveStepEditSession = (deps: SentencePlanEffectsDeps) => async (con
       user,
     })
   })
+
+  // The plan history page reads GOAL_UPDATED events. Step-level events are useful
+  // internally, but this goal-level event is what makes the change visible there.
+  if (hasStepChanges && !isCreatingGoal && activeGoal?.uuid) {
+    commands.push({
+      type: 'UpdateCollectionItemPropertiesCommand',
+      collectionItemUuid: activeGoal.uuid,
+      added: {},
+      removed: [],
+      timeline: {
+        type: 'GOAL_UPDATED',
+        data: {
+          goalUuid: activeGoal.uuid,
+          goalTitle: activeGoal.title,
+          updatedBy: getPractitionerName(context, user),
+        },
+      },
+      assessmentUuid,
+      user,
+    })
+  }
 
   // 4. REORDER commands
   existingSteps.forEach(({ id, index }) => {


### PR DESCRIPTION
Emit a GOAL_UPDATED timeline event when:

- a step actor is changed
- a step description is changed
- a new step is added
- an existing step is removed

Avoid creating a GOAL_UPDATED event when:

- step values are unchanged
- steps are being saved as part of creating a brand-new goal