### PR TITLE
Add listener for pending telemetry to ensure PageVisitTime is accurate for last page visit in session

### DIFF
--- a/assets/js/appInsights.mjs
+++ b/assets/js/appInsights.mjs
@@ -50,12 +50,10 @@ if (connectionString) {
 
   appInsights.trackPageView()
 
-  // flush pending telemetry (including PageVisitTime) when the page becomes hidden:
+  // flush pending telemetry (including PageVisitTime) before the page unloads:
   // in an MPA, the JS context is destroyed on navigation, so without this the SDK
   // may not deliver PageVisitTime before the page unloads
-  document.addEventListener('visibilitychange', () => {
-    if (document.hidden) {
-      appInsights.flush()
-    }
+  window.addEventListener('pagehide', () => {
+    appInsights.flush()
   })
 }

--- a/assets/js/appInsights.mjs
+++ b/assets/js/appInsights.mjs
@@ -49,4 +49,13 @@ if (connectionString) {
   })
 
   appInsights.trackPageView()
+
+  // flush pending telemetry (including PageVisitTime) when the page becomes hidden:
+  // in an MPA, the JS context is destroyed on navigation, so without this the SDK
+  // may not deliver PageVisitTime before the page unloads
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      appInsights.flush()
+    }
+  })
 }


### PR DESCRIPTION
## Context:
PageVisitTime is calculated through consecutive trackPageView() calls, where the SDK starts a timer when a page loads, and records the duration when the next trackPageView() fires (on the next page).

## Problem:
If a user visits one page and then closes the tab, there's no second trackPageView() call at all, so that visit is completely invisible in the metrics.

## Solution:
Added a pagehide listener that flushes all pending telemetry before the page unloads, ensuring PageVisitTime is sent before the browser destroys the page.