### PR TITLE
Fix: AppInsights page tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,9 @@ The application is deployed to Cloud Platform environments using GitHub Actions 
 
 **Page visit time & count**
 
-Page visit durations are tracked automatically by the App Insights JS SDK via `autoTrackPageVisitTime: true` (configured in `assets/js/appInsights.mjs`). The SDK measures time between page navigations and sends a `PageVisitTime` custom metric to the `customMetrics` table.
+Page visit durations are tracked by the App Insights JS SDK (configured in assets/js/appInsights.mjs). The SDK starts a timer on page load and records the visit duration when the user
+navigates away or closes the tab. The duration is stored in the duration field of the pageViews table.
+
 Pages currently tracked in App Insights dashboard:
 
 | Page                  | `customDimensions` filter                      |

--- a/assets/js/appInsights.mjs
+++ b/assets/js/appInsights.mjs
@@ -21,7 +21,7 @@ if (connectionString) {
       connectionString,
       disableXhr: true,
       blkCdnCfg: true,
-      autoTrackPageVisitTime: true,
+      autoTrackPageVisitTime: false,
       extensions: [clickAnalyticsPlugin],
       extensionConfig: {
         [clickAnalyticsPlugin.identifier]: clickAnalyticsConfig,
@@ -48,12 +48,13 @@ if (connectionString) {
     }
   })
 
-  appInsights.trackPageView()
+  appInsights.startTrackPage()
 
-  // flush pending telemetry (including PageVisitTime) before the page unloads:
-  // in an MPA, the JS context is destroyed on navigation, so without this the SDK
-  // may not deliver PageVisitTime before the page unloads
+  // stop the page visit timer and flush telemetry before the page unloads:
+  // in an MPA, the JS context is destroyed on navigation, so without this
+  // the last page of a session would never have its visit duration recorded
   window.addEventListener('pagehide', () => {
+    appInsights.stopTrackPage()
     appInsights.flush()
   })
 }


### PR DESCRIPTION
Switch to `appInsights.startTrackPage()` / `appInsights.stopTrackPage()` approach for tracking page visit time, as the `autoTrackPageVisitTime: true` didn't record the last page visited if a user closes a tab, as it relies on the next page to be loaded to send visit time for the previous page, resulting in the last page in the session being lost