### PR TITLE
SP2-2138: Remove sp-enable-teams-report-problem-link feature flag

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -25,7 +25,6 @@ generic-service:
     AUDIT_ENABLED: 'true'
     FEEDBACK_FORM_URL: 'https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2NZZrIGKlVRMlQWYqMMLQ_ZUQU4xRlA2RTQ0UFlXV1lJWjRPRlVSRE5LOS4u'
     SERVICE_NOW_FORM_URL: 'https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=276572591bce4910a93242ead34bcb53'
-    ARNS_MVP_COMMUNICATION_CHANNEL_URL: 'https://teams.microsoft.com/l/channel/19%3AdcmbxY-GfV8szUrt79R_dA60x0t-onk58ezRn5AXxCw1%40thread.tacv2/ARNS%20MVP%20Communication%20Channel?groupId=481bb11a-6765-4b68-b683-ce53bd404ac3&tenantId=c6874728-71e6-41fe-a9e1-2e8c36776ad8'
     FORM_TRAINING_SESSION_LAUNCHER_ENABLED: 'true'
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,7 +26,6 @@ generic-service:
     SMART_SURVEY_POPUP_CODE: '1U32TA'
     FEEDBACK_FORM_URL: 'https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2NZZrIGKlVRMlQWYqMMLQ_ZUQU4xRlA2RTQ0UFlXV1lJWjRPRlVSRE5LOS4u'
     SERVICE_NOW_FORM_URL: 'https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=276572591bce4910a93242ead34bcb53'
-    ARNS_MVP_COMMUNICATION_CHANNEL_URL: 'https://teams.microsoft.com/l/channel/19%3AdcmbxY-GfV8szUrt79R_dA60x0t-onk58ezRn5AXxCw1%40thread.tacv2/ARNS%20MVP%20Communication%20Channel?groupId=481bb11a-6765-4b68-b683-ce53bd404ac3&tenantId=c6874728-71e6-41fe-a9e1-2e8c36776ad8'
 
 generic-prometheus-alerts:
   targetApplication: hmpps-arns-assessment-platform-ui

--- a/server/config.ts
+++ b/server/config.ts
@@ -149,7 +149,6 @@ export default {
   environmentName: get('ENVIRONMENT_NAME', ''),
   feedbackFormUrl: get('FEEDBACK_FORM_URL', '#'),
   serviceNowFormUrl: get('SERVICE_NOW_FORM_URL', '#service-now-link', requiredInProduction),
-  arnsMvpCommunicationChannelUrl: get('ARNS_MVP_COMMUNICATION_CHANNEL_URL', '#arns-mvp-communication-channel'),
   oasysUrl: get('OASYS_URL', 'http://localhost:3000/training-session-launcher/sessions', requiredInProduction),
   mpopUrl: get('MPOP_URL', 'http://localhost:3000/sign-in', requiredInProduction),
   smartSurveyPopupCode: get('SMART_SURVEY_POPUP_CODE', ''),

--- a/server/forms/platform/views/platform-policy-step.njk
+++ b/server/forms/platform/views/platform-policy-step.njk
@@ -35,13 +35,8 @@
   {% block supportWidget %}
     {% set reportProblemHtml %}
       <p class="govuk-body">
-        {% if featureFlags and featureFlags.teamsReportProblemLinkEnabled %}
-          Copy this information and paste it into the
-          <a href="{{ arnsMvpCommunicationChannelUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ARNS MVP Communication Channel (opens in a new tab)</a>.
-        {% else %}
-          Copy this information and paste it into the
-          <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
-        {% endif %}
+        Copy this information and paste it into the
+        <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
       </p>
       <span id="copy-alert" class="govuk-visually-hidden" aria-live="polite"></span>
       <div class="app-report-problem__info">

--- a/server/forms/sentence-plan/views/sentence-plan-step.njk
+++ b/server/forms/sentence-plan/views/sentence-plan-step.njk
@@ -126,13 +126,8 @@
   {% block supportWidget %}
     {% set reportProblemHtml %}
       <p class="govuk-body">
-        {% if featureFlags and featureFlags.teamsReportProblemLinkEnabled %}
-          Copy this information and paste it into the
-          <a href="{{ arnsMvpCommunicationChannelUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ARNS MVP Communication Channel (opens in a new tab)</a>.
-        {% else %}
-          Copy this information and paste it into the
-          <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
-        {% endif %}
+        Copy this information and paste it into the
+        <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
       </p>
       <span id="copy-alert" class="govuk-visually-hidden" aria-live="polite"></span>
       <div class="app-report-problem__info">

--- a/server/forms/sentence-plan/views/simple-page.njk
+++ b/server/forms/sentence-plan/views/simple-page.njk
@@ -15,13 +15,8 @@
   {% block supportWidget %}
     {% set reportProblemHtml %}
       <p class="govuk-body">
-        {% if featureFlags and featureFlags.teamsReportProblemLinkEnabled %}
-          Copy this information and paste it into the
-          <a href="{{ arnsMvpCommunicationChannelUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ARNS MVP Communication Channel (opens in a new tab)</a>.
-        {% else %}
-          Copy this information and paste it into the
-          <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
-        {% endif %}
+        Copy this information and paste it into the
+        <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
       </p>
       <span id="copy-alert" class="govuk-visually-hidden" aria-live="polite"></span>
       <div class="app-report-problem__info">

--- a/server/middleware/setUpFeatureFlags.test.ts
+++ b/server/middleware/setUpFeatureFlags.test.ts
@@ -24,7 +24,7 @@ describe('setUpFeatureFlags', () => {
   it('should evaluate the configured boolean feature flags for the current user and store them in locals', async () => {
     const evaluateBooleanFlags = jest.fn().mockResolvedValue({
       booleanFeatureFlags: {
-        teamsReportProblemLinkEnabled: true,
+        smartSurveyInNationalRolloutEnabled: true,
       },
     })
     const featureFlagService = { evaluateBooleanFlags }
@@ -37,7 +37,7 @@ describe('setUpFeatureFlags', () => {
 
     expect(evaluateBooleanFlags).toHaveBeenCalledWith(BooleanFeatureFlags, 'user-123')
     expect(res.locals.featureFlags).toEqual({
-      teamsReportProblemLinkEnabled: true,
+      smartSurveyInNationalRolloutEnabled: true,
     })
     expect(next).toHaveBeenCalled()
   })
@@ -45,7 +45,7 @@ describe('setUpFeatureFlags', () => {
   it('should pass an undefined user ID when there is no current user', async () => {
     const evaluateBooleanFlags = jest.fn().mockResolvedValue({
       booleanFeatureFlags: {
-        teamsReportProblemLinkEnabled: false,
+        smartSurveyInNationalRolloutEnabled: false,
       },
     })
     const featureFlagService = { evaluateBooleanFlags }
@@ -58,7 +58,7 @@ describe('setUpFeatureFlags', () => {
 
     expect(evaluateBooleanFlags).toHaveBeenCalledWith(BooleanFeatureFlags, undefined)
     expect(res.locals.featureFlags).toEqual({
-      teamsReportProblemLinkEnabled: false,
+      smartSurveyInNationalRolloutEnabled: false,
     })
     expect(next).toHaveBeenCalled()
   })

--- a/server/utils/featureFlagsUtils.ts
+++ b/server/utils/featureFlagsUtils.ts
@@ -12,11 +12,6 @@ export const BooleanFeatureFlags = {
     nunjucksKey: 'smartSurveyInNationalRolloutEnabled',
     fallbackState: false,
   },
-  ENABLE_TEAMS_REPORT_PROBLEM_LINK: {
-    fliptKey: 'sp-enable-teams-report-problem-link',
-    nunjucksKey: 'teamsReportProblemLinkEnabled',
-    fallbackState: false,
-  },
 }
 
 export interface FeatureFlagConfig {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -17,7 +17,6 @@ export default function nunjucksSetup(app?: express.Express) {
     app.locals.environmentNameColour = config.environmentName === 'PRE-PRODUCTION' ? 'govuk-tag--green' : ''
     app.locals.feedbackFormUrl = config.feedbackFormUrl
     app.locals.serviceNowFormUrl = config.serviceNowFormUrl
-    app.locals.arnsMvpCommunicationChannelUrl = config.arnsMvpCommunicationChannelUrl
     app.locals.oasysUrl = config.oasysUrl
     app.locals.mpopUrl = config.mpopUrl
     app.locals.smartSurveyPopupCode = config.smartSurveyPopupCode

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -27,13 +27,8 @@
 {% block govukFooter %}
   {% set reportProblemHtml %}
     <p class="govuk-body">
-      {% if featureFlags and featureFlags.teamsReportProblemLinkEnabled %}
-        Copy this information and paste it into the
-        <a href="{{ arnsMvpCommunicationChannelUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ARNS MVP Communication Channel (opens in a new tab)</a>.
-      {% else %}
-        Copy this information and paste it into the
-        <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
-      {% endif %}
+      Copy this information and paste it into the
+      <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
     </p>
     <span id="copy-alert" class="govuk-visually-hidden" aria-live="polite"></span>
     <div class="app-report-problem__info">

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -72,13 +72,8 @@
 {% block govukFooter %}
   {% set reportProblemHtml %}
     <p class="govuk-body">
-      {% if featureFlags and featureFlags.teamsReportProblemLinkEnabled %}
-        Copy this information and paste it into the
-        <a href="{{ arnsMvpCommunicationChannelUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ARNS MVP Communication Channel (opens in a new tab)</a>.
-      {% else %}
-        Copy this information and paste it into the
-        <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
-      {% endif %}
+      Copy this information and paste it into the
+      <a href="{{ serviceNowFormUrl }}" class="govuk-link govuk-link--no-visited-state" target="_blank" rel="noopener noreferrer">ServiceNow form (opens in a new tab)</a>.
     </p>
     <span id="copy-alert" class="govuk-visually-hidden" aria-live="polite"></span>
     <div class="app-report-problem__info">


### PR DESCRIPTION
- The Teams variant of the "Report a problem" link was hidden behind this flag and is now turned off in national rollout.
- Removing the flag, the Teams branches in the 5 templates that used it, the registry entry, and updating the middleware tests to use a still-live flag.
- Follow-up: the flag definition still exists in Flipt - have raised a PR to remove these one this PR has been merged