### PR TITLE
Add ModSecurity WAF in DetectionOnly mode

### DIFF
--- a/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
@@ -19,8 +19,11 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-arns,tag:namespace={{ .Release.Namespace }}"
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"

--- a/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
@@ -16,6 +16,14 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-arns-assessment-platform-ui-cert
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-arns,tag:namespace={{ .Release.Namespace }}"
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
+++ b/helm_deploy/hmpps-arns-assessment-platform-ui/values.yaml
@@ -16,17 +16,6 @@ generic-service:
     enabled: true
     host: app-hostname.local # override per environment
     tlsSecretName: hmpps-arns-assessment-platform-ui-cert
-    modsecurity_enabled: true
-    modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
-      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
-      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positives
-      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   livenessProbe:
     httpGet:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,6 +4,14 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-dev.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-dev.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,8 +7,11 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positive
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -10,8 +10,11 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -7,6 +7,14 @@ autoscaling:
 generic-service:
   ingress:
     host: arns-assessment-platform-test.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-test.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
Enables ModSecurity (ModSec) WAF on the nginx ingress in DetectionOnly mode. 

- SecRuleEngine DetectionOnly - Logs what would be blocked without blocking anything 
- SecDefaultAction with `github_team=hmpps-assessments` - Tags every ModSec log entry so we can find them in OpenSearch using "ModSecurity" and "github_team=hmpps-assessments"
- SecRuleUpdateTargetById 920272 "!REQUEST_BODY" - Disables request body scanning, prevents free-text form fields (goal titles, step descriptions) triggering false positives 
- SecRuleUpdateActionById 949110 / 959100 - Changes ModSec's default block response from 403 to 406 - makes ModSec-blocked requests identifiable in logs
- SecAction paranoia_level=2 - Sets OWASP CRS sensitivity, level 2 gives good coverage without excessive noise          

Set to DetectionOnly mode - it gives us visibility of any false positives on legitimate SP journeys before we commit to full enforcement. 

Used https://github.com/ministryofjustice/hmpps-prisoner-location-api/blob/fa485243ae2211a8809162b1294e348759b72610/helm_deploy/hmpps-prisoner-location-api/values.yaml - as a template for the config
 