### PR TITLE
Modsec waf config fix

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,9 +12,9 @@ generic-service:
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positive
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
+      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-dev.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,12 +9,12 @@ generic-service:
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positive
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) dont trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,setvar:tx.paranoia_level=2"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-dev.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -9,7 +9,7 @@ generic-service:
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) dont trigger false positives
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -15,8 +15,8 @@ generic-service:
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
       SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -15,9 +15,9 @@ generic-service:
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
-      SecRuleUpdateActionById 949110 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecRuleUpdateActionById 959100 "t:none,deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
+      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-test.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,12 +12,12 @@ generic-service:
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) don't trigger false positives
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
-      SecAction "id:900000,phase:1,nolog,pass,setvar:tx.paranoia_level=2"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-test.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
- Add `t:none` back in
- Remove apostrophe - potentially breaking config