### PR TITLE
SP2-2206 : Plan Event Notes

### DIFF
--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.agreementContent.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.agreementContent.spec.ts
@@ -1,0 +1,171 @@
+import { expect } from '@playwright/test'
+import { test, TargetService } from '../../../support/fixtures'
+import PlanHistoryPage from '../../../pages/sentencePlan/planHistoryPage'
+import { handlePrivacyScreenIfPresent } from '../sentencePlanUtils'
+
+test.describe('Plan History - Agreement event expanded content', () => {
+  async function navigateToPlanHistory(page, handoverLink) {
+    await page.goto(handoverLink)
+    await handlePrivacyScreenIfPresent(page)
+    await page.getByRole('link', { name: /View plan history/i }).click()
+    return PlanHistoryPage.verifyOnPage(page)
+  }
+
+  function getSectionContent(page, headingPattern: RegExp) {
+    return page
+      .locator('.govuk-accordion__section', {
+        has: page.locator('.govuk-accordion__section-button', { hasText: headingPattern }),
+      })
+      .locator('.govuk-accordion__section-content')
+  }
+
+  async function expandSection(page, headingPattern: RegExp) {
+    await page
+      .locator('.govuk-accordion__section-button', { hasText: headingPattern })
+      .click()
+  }
+
+  test.describe('AGREED - notes present ', () => {
+    test('should display notes in expanded content when plan is agreed with notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      // Arrange
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          {
+            status: 'AGREED',
+            createdBy: 'Test Practitioner',
+            notes: 'Person reviewed and agreed to all goals',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      // Act
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Plan agreed/)
+
+      // Assert
+      const content = getSectionContent(page, /Plan agreed/)
+      await expect(content).toContainText('Person reviewed and agreed to all goals')
+    })
+  })
+
+  test.describe('AGREED - no notes', () => {
+    test('should display "No additional notes" in expanded content when plan is agreed without notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      // Arrange
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          {
+            status: 'AGREED',
+            createdBy: 'Test Practitioner',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      // Act
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Plan agreed/)
+
+      // Assert
+      const content = getSectionContent(page, /Plan agreed/)
+      await expect(content).toContainText('No additional notes')
+    })
+  })
+
+  test.describe('UPDATED_AGREED - notes present', () => {
+    test('should display notes in expanded content when agreement is updated to agreed with notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      // Arrange
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          { status: 'COULD_NOT_ANSWER', createdBy: 'Test Practitioner', dateOffset: -86400000 },
+          {
+            status: 'UPDATED_AGREED',
+            createdBy: 'Test Practitioner',
+            notes: 'Person now agrees after follow-up discussion',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      // Act
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Agreement updated/)
+
+      // Assert
+      const content = getSectionContent(page, /Agreement updated/)
+      await expect(content).toContainText('Person now agrees after follow-up discussion')
+    })
+  })
+
+  test.describe('UPDATED_AGREED - no notes', () => {
+    test('should display "No additional notes" when agreement is updated to agreed without notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      // Arrange
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          { status: 'COULD_NOT_ANSWER', createdBy: 'Test Practitioner', dateOffset: -86400000 },
+          { status: 'UPDATED_AGREED', createdBy: 'Test Practitioner', dateOffset: 0 },
+        ])
+        .save()
+
+      // Act
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Agreement updated/)
+
+      // Assert
+      const content = getSectionContent(page, /Agreement updated/)
+      await expect(content).toContainText('No additional notes')
+    })
+  })
+
+  test.describe('DO_NOT_AGREE - "No additional notes" not shown', () => {
+    test('should not display "No additional notes" for DO_NOT_AGREE events — only applies to AGREED/UPDATED_AGREED', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      // Arrange
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([{ status: 'DO_NOT_AGREE', createdBy: 'Test Practitioner', dateOffset: 0 }])
+        .save()
+
+      // Act
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Plan created/)
+
+      // Assert
+      const content = getSectionContent(page, /Plan created/)
+      await expect(content).not.toContainText('No additional notes')
+    })
+  })
+})

--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
@@ -44,7 +44,7 @@ test.describe('Plan History - Agreements', () => {
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
         - paragraph: View all updates to this plan.
         - button "Show all sections"
-        - heading /Agreement updated.*Follow-up Practitioner and Test.*Test agreed to this plan.*Person agreed after reviewing the plan/
+        - heading /Agreement updated.*Follow-up Practitioner and Test.*Test agreed to this plan/
         - heading /Plan created.*Initial Practitioner.*Test could not agree to this plan.*Person was not available to discuss the plan/
       `)
     })
@@ -77,7 +77,7 @@ test.describe('Plan History - Agreements', () => {
 
       const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-        - heading /Plan agreed.*First Practitioner and Test.*Test agreed to this plan.*Initial agreement notes/
+        - heading /Plan agreed.*First Practitioner and Test.*Test agreed to this plan/
       `)
     })
 
@@ -153,8 +153,8 @@ test.describe('Plan History - Agreements', () => {
 
       const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-        - heading /Agreement updated.*Person is now available and agrees/
-        - heading /Plan created.*Person was unavailable/
+        - heading /Agreement updated.*Second Practitioner and Test.*Test agreed to this plan/
+        - heading /Plan created.*First Practitioner.*Test could not agree to this plan/
       `)
     })
 
@@ -194,8 +194,8 @@ test.describe('Plan History - Agreements', () => {
 
       const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-        - heading /Agreement updated.*Test did not agree to this plan.*Person does not agree with the plan after reviewing it/
-        - heading /Plan created.*Test could not agree to this plan.*Person was in hospital/
+        - heading /Agreement updated.*Second Practitioner.*Test did not agree to this plan.*Person does not agree with the plan after reviewing it/
+        - heading /Plan created.*First Practitioner.*Test could not agree to this plan.*Person was in hospital/
       `)
     })
   })

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -26,9 +26,7 @@ const agreementHeadingHtml = Format(
     .else(''),
 )
 
-// Plan agreement event summary: status statement, plus an optional reason
-// (detailsNo for DO_NOT_AGREE, detailsCouldNotAnswer for COULD_NOT_ANSWER) and
-// optional free-text notes. Visible to all users — same access level as before.
+// Plan agreement event summary: the agreement status statement, always visible without expanding.
 const agreementStatusStatement = match(Item().path('status'))
   .branch(Condition.Array.IsIn(['AGREED', 'UPDATED_AGREED']), Format('%1 agreed to this plan.', CaseData.Forename))
   .branch(
@@ -37,25 +35,34 @@ const agreementStatusStatement = match(Item().path('status'))
   )
   .otherwise(Format('%1 could not agree to this plan.', CaseData.Forename))
 
-const agreementSummaryHtml = Format(
-  '<p class="govuk-body">%1</p>%2%3',
-  agreementStatusStatement,
-  when(Item().path('detailsNo').match(Condition.IsRequired()))
-    .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
-    .else(
-      when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
-        .then(
-          Format(
-            '<p class="govuk-body">%1</p>',
-            Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
-          ),
-        )
-        .else(''),
-    ),
-  when(Item().path('notes').match(Condition.IsRequired()))
-    .then(Format('<p class="govuk-body">%1</p>', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
-    .else(''),
-)
+const agreementSummaryHtml = Format('<p class="govuk-body">%1</p>', agreementStatusStatement)
+
+// Plan agreement event content: shown when the accordion section is expanded.
+// AGREED/UPDATED_AGREED show notes if present, otherwise "No additional notes".
+// Other statuses show their reason field if present, nothing if not.
+const agreementContentHtml = match(Item().path('status'))
+  .branch(
+    Condition.Array.IsIn(['AGREED', 'UPDATED_AGREED']),
+    when(Item().path('notes').match(Condition.IsRequired()))
+      .then(Format('<p class="govuk-body">%1</p>', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
+      .else('<p class="govuk-body">No additional notes</p>'),
+  )
+  .branch(
+    Condition.Array.IsIn(['DO_NOT_AGREE', 'UPDATED_DO_NOT_AGREE']),
+    when(Item().path('detailsNo').match(Condition.IsRequired()))
+      .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
+      .else(''),
+  )
+  .otherwise(
+    when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
+      .then(
+        Format(
+          '<p class="govuk-body">%1</p>',
+          Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
+        ),
+      )
+      .else(''),
+  )
 
 // Factory: builds a goal-event heading "<strong>{action}</strong> on {date} by {actorField}".
 // The actor field name varies per event (achievedBy, removedBy, readdedBy, etc.) — passed in.
@@ -100,8 +107,6 @@ const goalReaddedSummaryHtml = goalSummaryWithNotes('reason')
 const goalUpdatedHeadingHtml = goalHeading('Goal updated', 'updatedBy')
 const goalUpdatedSummaryHtml = goalSummaryWithNotes('notes')
 
-// Each entry becomes one accordion section. Heading + summary stay visible always;
-// content is empty for now and will hold expandable detail in a future iteration.
 export const agreementHistory = GovUKAccordion({
   id: 'plan-history-accordion',
   rememberExpanded: false,
@@ -125,7 +130,15 @@ export const agreementHistory = GovUKAccordion({
           .branch(Condition.Equals('goal_updated'), goalUpdatedSummaryHtml)
           .otherwise(agreementSummaryHtml),
       },
-      content: { html: '' },
+      content: {
+        html: match(Item().path('type'))
+          .branch(Condition.Equals('goal_achieved'), '')
+          .branch(Condition.Equals('goal_created'), '')
+          .branch(Condition.Equals('goal_removed'), '')
+          .branch(Condition.Equals('goal_readded'), '')
+          .branch(Condition.Equals('goal_updated'), '')
+          .otherwise(agreementContentHtml),
+      },
     }),
   ),
 })

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -26,7 +26,8 @@ const agreementHeadingHtml = Format(
     .else(''),
 )
 
-// Plan agreement event summary: the agreement status statement, always visible without expanding.
+// Plan agreement event summary: status statement plus reason, always visible without expanding.
+// Free-text notes are in the expandable content
 const agreementStatusStatement = match(Item().path('status'))
   .branch(Condition.Array.IsIn(['AGREED', 'UPDATED_AGREED']), Format('%1 agreed to this plan.', CaseData.Forename))
   .branch(
@@ -35,11 +36,26 @@ const agreementStatusStatement = match(Item().path('status'))
   )
   .otherwise(Format('%1 could not agree to this plan.', CaseData.Forename))
 
-const agreementSummaryHtml = Format('<p class="govuk-body">%1</p>', agreementStatusStatement)
+const agreementSummaryHtml = Format(
+  '<p class="govuk-body">%1</p>%2',
+  agreementStatusStatement,
+  when(Item().path('detailsNo').match(Condition.IsRequired()))
+    .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
+    .else(
+      when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
+        .then(
+          Format(
+            '<p class="govuk-body">%1</p>',
+            Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
+          ),
+        )
+        .else(''),
+    ),
+)
 
 // Plan agreement event content: shown when the accordion section is expanded.
-// AGREED/UPDATED_AGREED show notes if present, otherwise "No additional notes".
-// Other statuses show their reason field if present, nothing if not.
+// Only AGREED/UPDATED_AGREED have notes — show them if present, otherwise "No additional notes".
+// Other statuses have no notes field so content is empty.
 const agreementContentHtml = match(Item().path('status'))
   .branch(
     Condition.Array.IsIn(['AGREED', 'UPDATED_AGREED']),
@@ -47,22 +63,7 @@ const agreementContentHtml = match(Item().path('status'))
       .then(Format('<p class="govuk-body">%1</p>', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
       .else('<p class="govuk-body">No additional notes</p>'),
   )
-  .branch(
-    Condition.Array.IsIn(['DO_NOT_AGREE', 'UPDATED_DO_NOT_AGREE']),
-    when(Item().path('detailsNo').match(Condition.IsRequired()))
-      .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
-      .else(''),
-  )
-  .otherwise(
-    when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
-      .then(
-        Format(
-          '<p class="govuk-body">%1</p>',
-          Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
-        ),
-      )
-      .else(''),
-  )
+  .otherwise('')
 
 // Factory: builds a goal-event heading "<strong>{action}</strong> on {date} by {actorField}".
 // The actor field name varies per event (achievedBy, removedBy, readdedBy, etc.) — passed in.


### PR DESCRIPTION
[JIRA Ticket - SP2-2206 ](https://dsdmoj.atlassian.net/jira/software/c/projects/SP2/boards/1284?selectedIssue=SP2-2206)

Moves free-text notes for plan agreement events out of the always-visible accordion summary into the expandable content area:
  - Summary always shows the status statement (e.g. "John agreed to this plan.") plus any reason text for DO_NOT_AGREE and COULD_NOT_ANSWER events
 - Expandable content shows free-text notes for AGREED and UPDATED_AGREED events
 - Shows "No additional notes" when no notes were provided for AGREED or UPDATED_AGREED events
