### PR TITLE
SP2-2122 Plan history print view

### DIFF
--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.printView.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.printView.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from '@playwright/test'
+import { test, TargetService } from '../../../support/fixtures'
+import PlanHistoryPage from '../../../pages/sentencePlan/planHistoryPage'
+import { handlePrivacyScreenIfPresent } from '../sentencePlanUtils'
+
+test.describe(`Plan History - Print view`, () => {
+  test.beforeEach(async ({ page, createSession, sentencePlanBuilder }) => {
+    // Arrange: a plan with one goal and an agreement so the accordion has sections
+    const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+    await sentencePlanBuilder
+      .extend(sentencePlanId)
+      .withGoal({ title: 'Find stable accommodation', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+      .withPlanAgreements([{ status: 'AGREED', createdBy: 'Test Practitioner', dateOffset: 0 }])
+      .save()
+
+    await page.goto(handoverLink)
+    await handlePrivacyScreenIfPresent(page)
+    await page.getByRole('link', { name: /View plan history/i }).click()
+    await PlanHistoryPage.verifyOnPage(page)
+  })
+
+  test('should not show the "Show all sections" or "Hide all sections" controls when printed', async ({ page }) => {
+    // Act: switch the page into print media so print CSS applies to all assertions below
+    await page.emulateMedia({ media: 'print' })
+    await expect(page.locator('#plan-history-accordion .govuk-accordion__controls')).toBeHidden()
+  })
+
+  test('should not show the "Show" or "Hide" toggle text and chevron when printed ', async ({ page }) => {
+    await page.emulateMedia({ media: 'print' })
+
+    const toggles = page.locator('#plan-history-accordion .govuk-accordion__section-toggle')
+    const all = await toggles.all()
+    await Promise.all(all.map(toggle => expect(toggle).toBeHidden()))
+  })
+
+  test('should render section headings as non-interactive text when printed', async ({ page }) => {
+    await page.emulateMedia({ media: 'print' })
+
+    const headingButton = page.locator('#plan-history-accordion .govuk-accordion__section-button').first()
+    await expect(headingButton).toHaveCSS('pointer-events', 'none')
+    await expect(headingButton).toHaveCSS('cursor', 'text')
+  })
+
+  test('should still display plan history section headings when printed', async ({ page }) => {
+    await page.emulateMedia({ media: 'print' })
+    await expect(page.locator('#plan-history-accordion .govuk-accordion__section-heading-text').first()).toBeVisible()
+  })
+
+})

--- a/server/forms/sentence-plan/assets/form.scss
+++ b/server/forms/sentence-plan/assets/form.scss
@@ -103,4 +103,22 @@
   .govuk-footer {
     display: none !important;
   }
+
+  #plan-history-accordion {
+    //Hide the "Show all sections" / "Hide all sections" control
+    .govuk-accordion__controls {
+      display: none !important;
+    }
+
+    //Hide the "Show" / "Hide" toggle text and chevron
+    .govuk-accordion__section-toggle {
+      display: none !important;
+    }
+
+    //Make the heading button read as plain text, not an interactive link
+    .govuk-accordion__section-button {
+      cursor: text !important;
+      pointer-events: none !important;
+    }
+  }
 }


### PR DESCRIPTION
- Added CSS rules to hide interactive elements of the Plan History page when in print view
- Added e2e tests