### PR TITLE
SP2-2159: Plan history read-only (+ plan events updates)

### DIFF
--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.agreementContent.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.agreementContent.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test'
 import { test, TargetService } from '../../../support/fixtures'
 import PlanHistoryPage from '../../../pages/sentencePlan/planHistoryPage'
-import { handlePrivacyScreenIfPresent } from '../sentencePlanUtils'
+import { handlePrivacyScreenIfPresent, navigateToSentencePlan } from '../sentencePlanUtils'
 
 test.describe('Plan History - Agreement event expanded content', () => {
   async function navigateToPlanHistory(page, handoverLink) {
@@ -86,40 +86,8 @@ test.describe('Plan History - Agreement event expanded content', () => {
     })
   })
 
-  test.describe('UPDATED_AGREED - notes present', () => {
-    test('should display notes in expanded content when agreement is updated to agreed with notes', async ({
-      page,
-      createSession,
-      sentencePlanBuilder,
-    }) => {
-      // Arrange
-      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
-      await sentencePlanBuilder
-        .extend(sentencePlanId)
-        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
-        .withPlanAgreements([
-          { status: 'COULD_NOT_ANSWER', createdBy: 'Test Practitioner', dateOffset: -86400000 },
-          {
-            status: 'UPDATED_AGREED',
-            createdBy: 'Test Practitioner',
-            notes: 'Person now agrees after follow-up discussion',
-            dateOffset: 0,
-          },
-        ])
-        .save()
-
-      // Act
-      await navigateToPlanHistory(page, handoverLink)
-      await expandSection(page, /Agreement updated/)
-
-      // Assert
-      const content = getSectionContent(page, /Agreement updated/)
-      await expect(content).toContainText('Person now agrees after follow-up discussion')
-    })
-  })
-
   test.describe('UPDATED_AGREED - no notes', () => {
-    test('should display "No additional notes" when agreement is updated to agreed without notes', async ({
+    test('should display "No additional notes" when agreement is updated to agreed (as there is no text field to add these)', async ({
       page,
       createSession,
       sentencePlanBuilder,
@@ -145,8 +113,38 @@ test.describe('Plan History - Agreement event expanded content', () => {
     })
   })
 
+  test.describe('DO_NOT_AGREE - notes present ', () => {
+    test('should display details and notes in expanded content when plan is not agreed with notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          {
+            status: 'DO_NOT_AGREE',
+            createdBy: 'Test Practitioner',
+            detailsNo: 'Not agreed to plan',
+            notes: 'Person reviewed and disagreed with goals',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Plan created/)
+
+      const content = getSectionContent(page, /Plan created/)
+      await expect(content).toContainText('Not agreed to plan')
+      await expect(content).toContainText('Person reviewed and disagreed with goals')
+    })
+  })
+
   test.describe('DO_NOT_AGREE - "No additional notes" not shown', () => {
-    test('should not display "No additional notes" for DO_NOT_AGREE events — only applies to AGREED/UPDATED_AGREED', async ({
+    test('should display "No additional notes" in expanded content when plan is not agreed and no notes added ', async ({
       page,
       createSession,
       sentencePlanBuilder,
@@ -165,7 +163,100 @@ test.describe('Plan History - Agreement event expanded content', () => {
 
       // Assert
       const content = getSectionContent(page, /Plan created/)
-      await expect(content).not.toContainText('No additional notes')
+      await expect(content).toContainText('No additional notes.')
+    })
+  })
+
+  test.describe('UPDATED_DO_NOT_AGREE - mandatory details displayed, update agreement link removed', () => {
+    test('should display details information when agreement is updated to not agreed (as there is no text field to add these), remove update agreement link', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          { status: 'COULD_NOT_ANSWER', createdBy: 'Test Practitioner', dateOffset: -86400000 },
+          {
+            status: 'UPDATED_DO_NOT_AGREE',
+            detailsNo: `Person doesn't agree`,
+            createdBy: 'Test Practitioner',
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      await navigateToPlanHistory(page, handoverLink)
+      await expandSection(page, /Agreement updated/)
+
+      const content = getSectionContent(page, /Agreement updated/)
+      await expect(content).toContainText(`Person doesn't agree`)
+
+      await expandSection(page, /Plan created/)
+      const agreementCreatedContent = getSectionContent(page, /Plan created/)
+      await expect(agreementCreatedContent).not.toContainText(`Update Test's agreement`)
+    })
+  })
+
+  test.describe('COULD_NOT_ANSWER - notes present ', () => {
+    test('should display details and notes in expanded content when plan agreement status is COULD_NOT_ANSWER with notes', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          {
+            status: 'COULD_NOT_ANSWER',
+            createdBy: 'Test Practitioner',
+            detailsCouldNotAnswer: `Person wasn't present`,
+            notes: `Person didn't attend appointment`,
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      await navigateToSentencePlan(page, handoverLink)
+      await page.getByRole('link', { name: 'Plan history' }).click()
+      await expandSection(page, /Plan created/)
+
+      const content = getSectionContent(page, /Plan created/)
+      await expect(content).toContainText(`Person wasn't present`)
+      await expect(content).toContainText(`Person didn't attend appointment`)
+    })
+  })
+
+  test.describe('COULD_NOT_ANSWER - "No additional notes" not shown', () => {
+    test('should display "No additional notes" in expanded content when plan is not agreed and no notes added ', async ({
+      page,
+      createSession,
+      sentencePlanBuilder,
+    }) => {
+      const { sentencePlanId, handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withGoal({ title: 'Test goal', areaOfNeed: 'accommodation', status: 'ACTIVE' })
+        .withPlanAgreements([
+          {
+            status: 'COULD_NOT_ANSWER',
+            createdBy: 'Test Practitioner',
+            detailsCouldNotAnswer: `Person wasn't present`,
+            dateOffset: 0,
+          },
+        ])
+        .save()
+
+      await navigateToSentencePlan(page, handoverLink)
+      await page.getByRole('link', { name: 'Plan history' }).click()
+      await expandSection(page, /Plan created/)
+
+      const content = getSectionContent(page, /Plan created/)
+      await expect(content).toContainText('No additional notes.')
     })
   })
 })

--- a/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
+++ b/integration_tests/specs/sentencePlan/planHistory/planHistory.agreements.spec.ts
@@ -45,7 +45,7 @@ test.describe('Plan History - Agreements', () => {
         - paragraph: View all updates to this plan.
         - button "Show all sections"
         - heading /Agreement updated.*Follow-up Practitioner and Test.*Test agreed to this plan/
-        - heading /Plan created.*Initial Practitioner.*Test could not agree to this plan.*Person was not available to discuss the plan/
+        - heading /Plan created.*Initial Practitioner.*Test could not agree to this plan.*/
       `)
     })
   })
@@ -111,7 +111,7 @@ test.describe('Plan History - Agreements', () => {
 
       const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-        - heading /Plan created.*Test Practitioner.*Test did not agree to this plan.*Person disagrees with the goals set/
+        - heading /Plan created.*Test Practitioner.*/
       `)
     })
   })
@@ -194,8 +194,8 @@ test.describe('Plan History - Agreements', () => {
 
       const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
       await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-        - heading /Agreement updated.*Second Practitioner.*Test did not agree to this plan.*Person does not agree with the plan after reviewing it/
-        - heading /Plan created.*First Practitioner.*Test could not agree to this plan.*Person was in hospital/
+        - heading /Agreement updated.*Second Practitioner.*Test did not agree to this plan.*/
+        - heading /Plan created.*First Practitioner.*Test could not agree to this plan.*/
       `)
     })
   })

--- a/integration_tests/specs/sentencePlan/readOnlyMode/readOnlyMode.navigation.spec.ts
+++ b/integration_tests/specs/sentencePlan/readOnlyMode/readOnlyMode.navigation.spec.ts
@@ -3,6 +3,7 @@ import { test, TargetService } from '../../../support/fixtures'
 import PlanOverviewPage from '../../../pages/sentencePlan/planOverviewPage'
 import { currentGoals } from '../../../builders/sentencePlanFactories'
 import { navigateToSentencePlan, sentencePlanV1URLs, sentencePlanV1UrlBuilders } from '../sentencePlanUtils'
+import PlanHistoryPage from '../../../pages/sentencePlan/planHistoryPage'
 
 test.describe('READ_ONLY Access Mode', () => {
   test.describe('Privacy Screen', () => {
@@ -173,28 +174,62 @@ test.describe('READ_ONLY Access Mode', () => {
   })
 
   test.describe('Plan history entries', () => {
-    test('hides goal action links in READ_ONLY mode', async ({ page, createSession, sentencePlanBuilder }) => {
+    test('hides view goal links', async ({ page, createSession, sentencePlanBuilder }) => {
       const { sentencePlanId, handoverLink } = await createSession({
         targetService: TargetService.SENTENCE_PLAN,
         planAccessMode: 'READ_ONLY',
       })
       await sentencePlanBuilder
         .extend(sentencePlanId)
-        .withGoal({
-          title: 'Removed goal',
-          areaOfNeed: 'accommodation',
-          status: 'REMOVED',
-          notes: [{ type: 'REMOVED', note: 'No longer needed', createdBy: 'Test Practitioner' }],
-        })
+        .withGoals([
+          {
+            title: 'Find stable accommodation',
+            areaOfNeed: 'accommodation',
+            status: 'ACTIVE',
+            steps: [{ actor: 'probation_practitioner', description: 'Contact housing services' }],
+          },
+          {
+            title: 'Another goal',
+            areaOfNeed: 'accommodation',
+            status: 'ACHIEVED',
+          },
+          {
+            title: 'Another goal',
+            areaOfNeed: 'drug-use',
+            status: 'FUTURE',
+          },
+          {
+            title: 'Another goal',
+            areaOfNeed: 'drug-use',
+            status: 'REMOVED',
+          },
+        ])
         .withAgreementStatus('AGREED')
         .save()
 
       await navigateToSentencePlan(page, handoverLink)
       await page.goto(sentencePlanV1URLs.PLAN_HISTORY)
+      const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
+      await planHistoryPage.clickShowAllSectionsButton()
 
-      await expect(
-        page.getByTestId('main-form').getByRole('link', { name: /View goal|View latest version/i }),
-      ).toHaveCount(0)
+      await expect(page.getByTestId('main-form').getByRole('link', { name: 'View goal' })).toHaveCount(0)
+    })
+    test('hides update agreement link', async ({ page, createSession, sentencePlanBuilder }) => {
+      const { sentencePlanId, handoverLink } = await createSession({
+        targetService: TargetService.SENTENCE_PLAN,
+        planAccessMode: 'READ_ONLY',
+      })
+      await sentencePlanBuilder
+        .extend(sentencePlanId)
+        .withAgreementStatus('COULD_NOT_ANSWER')
+        .save()
+
+      await navigateToSentencePlan(page, handoverLink)
+      await page.goto(sentencePlanV1URLs.PLAN_HISTORY)
+      const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
+      await planHistoryPage.clickShowAllSectionsButton()
+
+      await expect(page.getByTestId('main-form').getByTestId('plan-history-update-agreement-link')).toHaveCount(0)
     })
   })
 })

--- a/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.planHistory.spec.ts
+++ b/integration_tests/specs/sentencePlan/updateAgreePlan/updateAgreePlan.planHistory.spec.ts
@@ -53,9 +53,12 @@ test.describe('Update agree plan - Plan history', () => {
     await page.goto(sentencePlanV1URLs.PLAN_HISTORY)
     const planHistoryPage = await PlanHistoryPage.verifyOnPage(page)
 
+    await planHistoryPage.clickShowAllSectionsButton()
+
     // Verify updated agreement entry with disagreement details
     await expect(planHistoryPage.mainContent).toMatchAriaSnapshot(`
-      - heading /Agreement updated.*did not agree.*They disagree with the current goals/
+      - heading /Agreement updated.*did not agree.*/
+      - paragraph: They disagree with the current goals.
       - heading /Plan created/
     `)
   })

--- a/server/forms/sentence-plan/versions/v1.0/guards.ts
+++ b/server/forms/sentence-plan/versions/v1.0/guards.ts
@@ -30,6 +30,7 @@ export const lacksPostAgreementStatus = Data('latestAgreementStatus').not.match(
 export const hasCouldNotAnswerStatus = Data('latestAgreementStatus').match(Condition.Equals('COULD_NOT_ANSWER'))
 
 export const lacksCouldNotAnswerStatus = Data('latestAgreementStatus').not.match(Condition.Equals('COULD_NOT_ANSWER'))
+export const isCouldNotAnswerStatus = Data('latestAgreementStatus').match(Condition.Equals('COULD_NOT_ANSWER'))
 
 /**
  * Redirect users with READ_ONLY access to plan overview.

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -7,6 +7,7 @@ import { GovUKBody } from '@form-engine-govuk-components/wrappers/govukBody'
 import { HtmlBlock } from '@form-engine/registry/components/html'
 import { GoalSummaryCardHistory } from '../../../../../../components'
 import { CaseData } from '../../../../constants'
+import { isCouldNotAnswerStatus, isReadOnlyAccess } from '../../../../guards'
 
 const GOAL_EVENT_TYPES = ['goal_created', 'goal_achieved', 'goal_removed', 'goal_readded', 'goal_updated']
 const INACTIVE_GOAL_STATUSES = ['ACHIEVED', 'REMOVED']
@@ -41,34 +42,53 @@ const agreementStatusStatement = match(Item().path('status'))
   )
   .otherwise(Format('%1 could not agree to this plan.', CaseData.Forename))
 
-const agreementSummaryHtml = Format(
-  '<p class="govuk-body">%1</p>%2',
-  agreementStatusStatement,
-  when(Item().path('detailsNo').match(Condition.IsRequired()))
-    .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
-    .else(
-      when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
-        .then(
-          Format(
-            '<p class="govuk-body">%1</p>',
-            Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
-          ),
-        )
-        .else(''),
-    ),
-)
+const agreementSummaryHtml = Format('<p class="govuk-body">%1</p>', agreementStatusStatement)
 
 // Plan agreement event content: shown when the accordion section is expanded.
-// Only AGREED/UPDATED_AGREED have notes — show them if present, otherwise "No additional notes".
-// Other statuses have no notes field so content is empty.
-const agreementContentHtml = match(Item().path('status'))
-  .branch(
-    Condition.Array.IsIn(['AGREED', 'UPDATED_AGREED']),
-    when(Item().path('notes').match(Condition.IsRequired()))
-      .then(Format('<p class="govuk-body">%1</p>', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
-      .else('<p class="govuk-body">No additional notes.</p>'),
+const agreementContentHtml = Format(
+  `
+   <p class="govuk-body">%1</p>
+   <p class="govuk-body">%2</p>
+   <p class="govuk-body">%3</p>
+  `,
+  // mandatory details for DO_NOT_AGREE/UPDATED_DO_NOT_AGREE/COULD_NOT_ANSWER events:
+  when(Item().path('detailsNo').match(Condition.IsRequired()))
+    .then(Format('%1', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
+    .else(
+      when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
+        .then(Format('%1', Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml())))
+        .else(''),
+    ),
+
+  // optional notes for AGREED/DO_NOT_AGREE/COULD_NOT_ANSWER events - show if present, otherwise `No additional notes.`
+  // UPDATED_DO_NOT_AGREE/UPDATED_AGREED have no optional notes text box,
+  // however because UPDATED_AGREED has no details field to show in expander `No additional notes.` is shown instead
+  when(
+    Item()
+      .path('status')
+      .match(Condition.Array.IsIn(['AGREED', 'DO_NOT_AGREE', 'COULD_NOT_ANSWER', 'UPDATED_AGREED'])),
   )
-  .otherwise('')
+    .then(
+      when(Item().path('notes').match(Condition.IsRequired()))
+        .then(Format('%1', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
+        .else('No additional notes.'),
+    )
+    .else(''),
+
+  // update agreement link for COULD_NOT_ANSWER events (hidden in read-only):
+  when(isCouldNotAnswerStatus)
+    .then(
+      when(isReadOnlyAccess)
+        .then('')
+        .else(
+          Format(
+            `<a href="update-agree-plan" class="govuk-link govuk-link--no-visited-state" data-qa="plan-history-update-agreement-link">Update %1 agreement</a>`,
+            CaseData.ForenamePossessive,
+          ),
+        ),
+    )
+    .else(''),
+)
 
 // Factory: builds a goal-event heading "<strong>{action}</strong> on {date} by {actorField}".
 // The actor field name varies per event (achievedBy, removedBy, readdedBy, etc.) — passed in.
@@ -138,6 +158,7 @@ const goalSummaryCardForHistory = GoalSummaryCardHistory({
       href: when(Item().path('currentGoalStatus').match(Condition.Array.IsIn(INACTIVE_GOAL_STATUSES)))
         .then(Format('../goal/%1/view-inactive-goal', Item().path('goalUuid')))
         .else(Format('../goal/%1/update-goal-steps', Item().path('goalUuid'))),
+      hidden: when(isReadOnlyAccess),
     },
   ],
 })

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -46,17 +46,18 @@ const agreementSummaryHtml = Format('<p class="govuk-body">%1</p>', agreementSta
 
 // Plan agreement event content: shown when the accordion section is expanded.
 const agreementContentHtml = Format(
-  `
-   <p class="govuk-body">%1</p>
-   <p class="govuk-body">%2</p>
-   <p class="govuk-body">%3</p>
-  `,
+  '%1 %2 %3',
   // mandatory details for DO_NOT_AGREE/UPDATED_DO_NOT_AGREE/COULD_NOT_ANSWER events:
   when(Item().path('detailsNo').match(Condition.IsRequired()))
-    .then(Format('%1', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
+    .then(Format('<p class="govuk-body">%1</p>', Item().path('detailsNo').pipe(Transformer.String.EscapeHtml())))
     .else(
       when(Item().path('detailsCouldNotAnswer').match(Condition.IsRequired()))
-        .then(Format('%1', Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml())))
+        .then(
+          Format(
+            '<p class="govuk-body">%1</p>',
+            Item().path('detailsCouldNotAnswer').pipe(Transformer.String.EscapeHtml()),
+          ),
+        )
         .else(''),
     ),
 
@@ -70,8 +71,8 @@ const agreementContentHtml = Format(
   )
     .then(
       when(Item().path('notes').match(Condition.IsRequired()))
-        .then(Format('%1', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
-        .else('No additional notes.'),
+        .then(Format('<p class="govuk-body">%1</p>', Item().path('notes').pipe(Transformer.String.EscapeHtml())))
+        .else('<p class="govuk-body">No additional notes.</p>'),
     )
     .else(''),
 
@@ -82,7 +83,7 @@ const agreementContentHtml = Format(
         .then('')
         .else(
           Format(
-            `<a href="update-agree-plan" class="govuk-link govuk-link--no-visited-state" data-qa="plan-history-update-agreement-link">Update %1 agreement</a>`,
+            `<p class="govuk-body"><a href="update-agree-plan" class="govuk-link govuk-link--no-visited-state" data-qa="plan-history-update-agreement-link">Update %1 agreement</a></p>`,
             CaseData.ForenamePossessive,
           ),
         ),


### PR DESCRIPTION
## Read-only changes:

- remove `update agreement` and `view goal` links for `READ_ONLY` users

- add e2e tests to confirm the above behaviour

## Plan events updates:

- add `update agreement` link inside the expander (hidden for read-only/once agreement updated to `updated agreed`/ `updated do not agree`)

- include optional notes for `do not agree` and `could not answer` inside expanders

- add default `No additional notes.` text for `updated agree` event as per design below (as it has no related mandatory details/optional notes text boxes)

- move mandatory details inside the expander for the plan events in accordance with the following designs:
<img width="1230" height="3596" alt="image" src="https://github.com/user-attachments/assets/6d327abc-b8c6-4e28-9176-e15c914155f9" />

- add & update e2e tests to confirm the above behaviour
