### PR TITLE
Enable ModSec WAF: blocking in dev/test, DetectionOnly in preprod/prod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,6 +4,18 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-preprod.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform-preprod.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,6 +4,18 @@
 generic-service:
   ingress:
     host: arns-assessment-platform.hmpps.service.justice.gov.uk
+    modsecurity_enabled: true
+    modsecurity_audit_enabled: true
+    modsecurity_snippet: |
+      SecRuleEngine DetectionOnly
+      # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
+      SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
+      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
+      SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"
+      SecAction "id:900000,phase:1,nolog,pass,t:none,setvar:tx.paranoia_level=2"
 
   env:
     INGRESS_URL: 'https://arns-assessment-platform.hmpps.service.justice.gov.uk'

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -7,7 +7,7 @@ generic-service:
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
-      SecRuleEngine DetectionOnly
+      SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives


### PR DESCRIPTION
Final WAF test configuration for the ARNS Assessment Platform UI.

Sets the ModSecurity WAF to **blocking** in lower environments and **logging-only** in pre-prod and prod environments:

We want one last test of the existing WAF ruleset with rules actively enforcing in dev and test, while preprod and prod run in DetectionOnly (log-only) so we can observe what *would* be blocked against production-like traffic before enabling enforcement there.