### PR TITLE
Add guard for accessing assessment info to reduce unnecessary calls to coordinator API

### DIFF
--- a/server/forms/sentence-plan/effects/goals/loadAllAreasAssessmentInfo.ts
+++ b/server/forms/sentence-plan/effects/goals/loadAllAreasAssessmentInfo.ts
@@ -4,7 +4,7 @@ import { transformAssessmentData } from '../../../../utils/assessmentUtils'
 import { mapHandoverToCriminogenicNeeds } from '../../../../utils/handoverApiMapper'
 import { SentencePlanContext, SentencePlanEffectsDeps } from '../types'
 import { AssessmentArea } from '../../../../interfaces/coordinator-api/entityAssessment'
-import { canAccessSanContent } from '../helpers'
+import { canAccessSanInfo } from '../helpers'
 
 // Loads assessment information for ALL areas of need and groups them by scoring category.
 
@@ -18,7 +18,7 @@ import { canAccessSanContent } from '../helpers'
 // - lowScoringAreas: complete and score < threshold
 // - otherAreas: Finance, Health & wellbeing once completed (no scoring)
 export const loadAllAreasAssessmentInfo = (deps: SentencePlanEffectsDeps) => async (context: SentencePlanContext) => {
-  if (!canAccessSanContent(context)) {
+  if (!canAccessSanInfo(context)) {
     setUnavailableState(context)
     return
   }

--- a/server/forms/sentence-plan/effects/goals/loadAllAreasAssessmentInfo.ts
+++ b/server/forms/sentence-plan/effects/goals/loadAllAreasAssessmentInfo.ts
@@ -4,6 +4,7 @@ import { transformAssessmentData } from '../../../../utils/assessmentUtils'
 import { mapHandoverToCriminogenicNeeds } from '../../../../utils/handoverApiMapper'
 import { SentencePlanContext, SentencePlanEffectsDeps } from '../types'
 import { AssessmentArea } from '../../../../interfaces/coordinator-api/entityAssessment'
+import { canAccessSanContent } from '../helpers'
 
 // Loads assessment information for ALL areas of need and groups them by scoring category.
 
@@ -17,6 +18,11 @@ import { AssessmentArea } from '../../../../interfaces/coordinator-api/entityAss
 // - lowScoringAreas: complete and score < threshold
 // - otherAreas: Finance, Health & wellbeing once completed (no scoring)
 export const loadAllAreasAssessmentInfo = (deps: SentencePlanEffectsDeps) => async (context: SentencePlanContext) => {
+  if (!canAccessSanContent(context)) {
+    setUnavailableState(context)
+    return
+  }
+
   const assessmentUuid = context.getData('assessmentUuid')
   const session = context.getSession()
   const handoverCriminogenicNeeds = session.handoverContext?.criminogenicNeedsData
@@ -77,6 +83,18 @@ export const loadAllAreasAssessmentInfo = (deps: SentencePlanEffectsDeps) => asy
     logger.error({ err: error, assessmentUuid, crn }, 'Failed to load all areas assessment info')
     setErrorState(context)
   }
+}
+
+const setUnavailableState = (context: SentencePlanContext): void => {
+  context.setData('allAssessmentAreas', [])
+  context.setData('highScoringAreas', [])
+  context.setData('lowScoringAreas', [])
+  context.setData('otherAreas', [])
+  context.setData('incompleteAreas', [])
+  context.setData('isAssessmentComplete', false)
+  context.setData('assessmentLastUpdated', null)
+  context.setData('allAreasAssessmentStatus', 'unavailable')
+  context.setData('areasByGoalRoute', {})
 }
 
 const setErrorState = (context: SentencePlanContext): void => {

--- a/server/forms/sentence-plan/effects/goals/loadAreaAssessmentInfo.ts
+++ b/server/forms/sentence-plan/effects/goals/loadAreaAssessmentInfo.ts
@@ -2,8 +2,15 @@ import logger from '../../../../../logger'
 import { transformAssessmentData } from '../../../../utils/assessmentUtils'
 import { mapHandoverToCriminogenicNeeds } from '../../../../utils/handoverApiMapper'
 import { SentencePlanContext, SentencePlanEffectsDeps } from '../types'
+import { canAccessSanContent } from '../helpers'
 
 export const loadAreaAssessmentInfo = (deps: SentencePlanEffectsDeps) => async (context: SentencePlanContext) => {
+  if (!canAccessSanContent(context)) {
+    context.setData('currentAreaAssessment', null)
+    context.setData('currentAreaAssessmentStatus', 'unavailable')
+    return
+  }
+
   const assessmentUuid = context.getData('assessmentUuid')
   const currentAreaOfNeed = context.getData('currentAreaOfNeed')
   const session = context.getSession()

--- a/server/forms/sentence-plan/effects/goals/loadAreaAssessmentInfo.ts
+++ b/server/forms/sentence-plan/effects/goals/loadAreaAssessmentInfo.ts
@@ -2,10 +2,10 @@ import logger from '../../../../../logger'
 import { transformAssessmentData } from '../../../../utils/assessmentUtils'
 import { mapHandoverToCriminogenicNeeds } from '../../../../utils/handoverApiMapper'
 import { SentencePlanContext, SentencePlanEffectsDeps } from '../types'
-import { canAccessSanContent } from '../helpers'
+import { canAccessSanInfo } from '../helpers'
 
 export const loadAreaAssessmentInfo = (deps: SentencePlanEffectsDeps) => async (context: SentencePlanContext) => {
-  if (!canAccessSanContent(context)) {
+  if (!canAccessSanInfo(context)) {
     context.setData('currentAreaAssessment', null)
     context.setData('currentAreaAssessmentStatus', 'unavailable')
     return

--- a/server/forms/sentence-plan/effects/helpers.test.ts
+++ b/server/forms/sentence-plan/effects/helpers.test.ts
@@ -1,5 +1,5 @@
 import { SentencePlanContext } from './types'
-import { canAccessSanContent } from './helpers'
+import { canAccessSanInfo } from './helpers'
 
 const createMockContext = (
   overrides: {
@@ -13,14 +13,14 @@ const createMockContext = (
     getSession: jest.fn(() => overrides.session ?? {}),
   }) as unknown as SentencePlanContext
 
-describe('canAccessSanContent()', () => {
+describe('canAccessSanInfo()', () => {
   it('should return true when assessment has SAN_BETA flag and access is not MPoP', () => {
     const context = createMockContext({
       data: { assessment: { flags: ['SAN_BETA'] } },
       session: { sessionDetails: { accessType: 'OASYS' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(true)
+    expect(canAccessSanInfo(context)).toBe(true)
   })
 
   it('should return false when assessment has no SAN_BETA flag', () => {
@@ -29,7 +29,7 @@ describe('canAccessSanContent()', () => {
       session: { sessionDetails: { accessType: 'OASYS' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(false)
+    expect(canAccessSanInfo(context)).toBe(false)
   })
 
   it('should return false when access type is HMPPS_AUTH (MPoP)', () => {
@@ -38,7 +38,7 @@ describe('canAccessSanContent()', () => {
       session: { sessionDetails: { accessType: 'HMPPS_AUTH' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(false)
+    expect(canAccessSanInfo(context)).toBe(false)
   })
 
   it('should return false when assessment has no flags property', () => {
@@ -47,7 +47,7 @@ describe('canAccessSanContent()', () => {
       session: { sessionDetails: { accessType: 'OASYS' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(false)
+    expect(canAccessSanInfo(context)).toBe(false)
   })
 
   it('should return false when assessment is undefined', () => {
@@ -55,7 +55,7 @@ describe('canAccessSanContent()', () => {
       session: { sessionDetails: { accessType: 'OASYS' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(false)
+    expect(canAccessSanInfo(context)).toBe(false)
   })
 
   it('should return true when sessionDetails is undefined', () => {
@@ -63,7 +63,7 @@ describe('canAccessSanContent()', () => {
       data: { assessment: { flags: ['SAN_BETA'] } },
     })
 
-    expect(canAccessSanContent(context)).toBe(true)
+    expect(canAccessSanInfo(context)).toBe(true)
   })
 
   it('should return false when both SAN_BETA is missing and access is MPoP', () => {
@@ -72,6 +72,6 @@ describe('canAccessSanContent()', () => {
       session: { sessionDetails: { accessType: 'HMPPS_AUTH' } },
     })
 
-    expect(canAccessSanContent(context)).toBe(false)
+    expect(canAccessSanInfo(context)).toBe(false)
   })
 })

--- a/server/forms/sentence-plan/effects/helpers.test.ts
+++ b/server/forms/sentence-plan/effects/helpers.test.ts
@@ -1,0 +1,77 @@
+import { SentencePlanContext } from './types'
+import { canAccessSanContent } from './helpers'
+
+const createMockContext = (
+  overrides: {
+    data?: Record<string, unknown>
+    session?: Record<string, unknown>
+  } = {},
+): SentencePlanContext =>
+  ({
+    getData: jest.fn((key: string) => overrides.data?.[key]),
+    setData: jest.fn(),
+    getSession: jest.fn(() => overrides.session ?? {}),
+  }) as unknown as SentencePlanContext
+
+describe('canAccessSanContent()', () => {
+  it('should return true when assessment has SAN_BETA flag and access is not MPoP', () => {
+    const context = createMockContext({
+      data: { assessment: { flags: ['SAN_BETA'] } },
+      session: { sessionDetails: { accessType: 'OASYS' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(true)
+  })
+
+  it('should return false when assessment has no SAN_BETA flag', () => {
+    const context = createMockContext({
+      data: { assessment: { flags: [] } },
+      session: { sessionDetails: { accessType: 'OASYS' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(false)
+  })
+
+  it('should return false when access type is HMPPS_AUTH (MPoP)', () => {
+    const context = createMockContext({
+      data: { assessment: { flags: ['SAN_BETA'] } },
+      session: { sessionDetails: { accessType: 'HMPPS_AUTH' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(false)
+  })
+
+  it('should return false when assessment has no flags property', () => {
+    const context = createMockContext({
+      data: { assessment: { assessmentUuid: 'some-uuid' } },
+      session: { sessionDetails: { accessType: 'OASYS' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(false)
+  })
+
+  it('should return false when assessment is undefined', () => {
+    const context = createMockContext({
+      session: { sessionDetails: { accessType: 'OASYS' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(false)
+  })
+
+  it('should return true when sessionDetails is undefined', () => {
+    const context = createMockContext({
+      data: { assessment: { flags: ['SAN_BETA'] } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(true)
+  })
+
+  it('should return false when both SAN_BETA is missing and access is MPoP', () => {
+    const context = createMockContext({
+      data: { assessment: { flags: [] } },
+      session: { sessionDetails: { accessType: 'HMPPS_AUTH' } },
+    })
+
+    expect(canAccessSanContent(context)).toBe(false)
+  })
+})

--- a/server/forms/sentence-plan/effects/helpers.ts
+++ b/server/forms/sentence-plan/effects/helpers.ts
@@ -1,0 +1,12 @@
+import { SentencePlanContext } from './types'
+
+// Requires both a SAN_SP assessment (SAN_BETA flag) AND non-MPoP access,
+// because MPoP users cannot reach the SAN data APIs needed to populate this content.
+export const canAccessSanContent = (context: SentencePlanContext): boolean => {
+  const assessment = context.getData('assessment')
+  const sessionDetails = context.getSession().sessionDetails
+  const isSanSp = assessment && 'flags' in assessment && assessment.flags?.includes('SAN_BETA')
+  const isMpop = sessionDetails?.accessType === 'HMPPS_AUTH'
+
+  return Boolean(isSanSp && !isMpop)
+}

--- a/server/forms/sentence-plan/effects/helpers.ts
+++ b/server/forms/sentence-plan/effects/helpers.ts
@@ -2,7 +2,7 @@ import { SentencePlanContext } from './types'
 
 // Requires both a SAN_SP assessment (SAN_BETA flag) AND non-MPoP access,
 // because MPoP users cannot reach the SAN data APIs needed to populate this content.
-export const canAccessSanContent = (context: SentencePlanContext): boolean => {
+export const canAccessSanInfo = (context: SentencePlanContext): boolean => {
   const assessment = context.getData('assessment')
   const sessionDetails = context.getSession().sessionDetails
   const isSanSp = assessment && 'flags' in assessment && assessment.flags?.includes('SAN_BETA')

--- a/server/forms/sentence-plan/effects/types.ts
+++ b/server/forms/sentence-plan/effects/types.ts
@@ -25,8 +25,9 @@ import FeatureFlagService from '../../../services/featureFlagService'
  *
  * - 'success': Data loaded successfully (data may or may not be present depending on assessment state)
  * - 'error': Failed to load data from one or both sources
+ * - 'unavailable': Assessment data is not applicable (such as SP-only assessment without SAN data)
  */
-export type AssessmentInfoStatus = 'success' | 'error'
+export type AssessmentInfoStatus = 'success' | 'error' | 'unavailable'
 
 export interface AccessDetails {
   accessType: AuthSource


### PR DESCRIPTION
## Context 
Only a user with `SAN_SP` assessment AND non-MPoP access (MPoP users cannot reach the SAN data APIs needed to populate this content) can access SAN-specific content.

## Issue
When a user who is not meant to see SAN content accesses a page with conditional assessmentInfo content, the UI makes a call to the coordinator API and returns a 404, which creates unnecessary noise in the logs and makes it more difficult to pinpoint real issues.

## Solution
Create a `canAccessSanContent` helper and use it in `loadAreaAssessmentInfo` & `loadAllAreasAssessmentInfo` to return early, before the coordinator API is called.

**Note**: About page already uses a template guard in steps' onAccess/conditional rendering of a button, however, to ensure self-sufficiency of `loadAllAreasAssessmentInfo`, `canAccessSanContent` is also added there.