### PR TITLE
SP2-2237: Add WrappingSelect component for long actor names

### DIFF
--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -9,6 +9,7 @@ $govuk-page-width: $moj-page-width;
 @import 'accessible-autocomplete/dist/accessible-autocomplete.min.css';
 @import '../../server/forms/sentence-plan/components/accessible-autocomplete/accessible-autocomplete';
 @import '@ministryofjustice/hmpps-forge/dist/moj-components/all';
+@import '../../server/forms/sentence-plan/components/wrapping-select/wrapping-select';
 
 // Highlight.js theme for syntax highlighting
 @import 'highlight.js/styles/github';

--- a/integration_tests/pages/sentencePlan/addStepsPage.ts
+++ b/integration_tests/pages/sentencePlan/addStepsPage.ts
@@ -57,7 +57,9 @@ export default class AddStepsPage extends AbstractPage {
     const descriptionInput = await this.getStepDescriptionInput(index)
     const statusSelect = await this.getStepStatusSelect(index)
 
-    await actorSelect.selectOption(actor)
+    // The WrappingSelect combobox visually hides the underlying <select> on init.
+    // Tests can still set its value with force: true; form submission reads the select.
+    await actorSelect.selectOption(actor, { force: true })
     await descriptionInput.fill(description)
     await statusSelect.selectOption(status)
   }

--- a/integration_tests/specs/sentencePlan/createGoal.spec.ts
+++ b/integration_tests/specs/sentencePlan/createGoal.spec.ts
@@ -165,7 +165,7 @@ test.describe('Create Goal Journey', () => {
         (rowBox?.height ?? 0) -
         ((expandedDescriptionBox?.y ?? 0) + (expandedDescriptionBox?.height ?? 0))
 
-      expect(descriptionBottomGap).toBeLessThanOrEqual(6)
+      expect(descriptionBottomGap).toBeLessThanOrEqual(12)
     })
 
     test('shows goal added notification after creating goal with steps', async ({ page, createSession }) => {

--- a/server/forms/sentence-plan/assets/form.js
+++ b/server/forms/sentence-plan/assets/form.js
@@ -7,3 +7,4 @@
 
 import '../components/accessible-autocomplete/accessible-autocomplete.mjs'
 import '../components/copy-button/copy-button.mjs'
+import '../components/wrapping-select/wrapping-select.mjs'

--- a/server/forms/sentence-plan/assets/form.scss
+++ b/server/forms/sentence-plan/assets/form.scss
@@ -57,7 +57,7 @@
 
 .step-row {
   align-items: start;
-  padding-bottom: govuk-spacing(1);
+  padding-bottom: govuk-spacing(2);
   margin-bottom: govuk-spacing(3);
   border-bottom: 1px solid $govuk-border-colour;
 

--- a/server/forms/sentence-plan/components/index.ts
+++ b/server/forms/sentence-plan/components/index.ts
@@ -3,11 +3,13 @@ import { assessmentInfoDetails } from './assessment-info-details/assessmentInfoD
 import { buttonAsLink } from './button-as-link/buttonAsLink'
 import { goalSummaryCardAgreed, goalSummaryCardDraft } from './goal-summary-card/goalSummaryCard'
 import { previousVersions } from './previous-versions/previousVersions'
+import { wrappingSelect } from './wrapping-select/wrappingSelect'
 
 export { AccessibleAutocomplete } from './accessible-autocomplete/accessibleAutocomplete'
 export { AssessmentInfoDetails } from './assessment-info-details/assessmentInfoDetails'
 export { ButtonAsLink } from './button-as-link/buttonAsLink'
 export { GoalSummaryCardAgreed, GoalSummaryCardDraft } from './goal-summary-card/goalSummaryCard'
+export { WrappingSelect } from './wrapping-select/wrappingSelect'
 
 export const sentencePlanComponents = [
   accessibleAutocomplete,
@@ -16,4 +18,5 @@ export const sentencePlanComponents = [
   goalSummaryCardDraft,
   goalSummaryCardAgreed,
   previousVersions,
+  wrappingSelect,
 ]

--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
@@ -1,0 +1,273 @@
+/**
+ * WrappingSelect: an accessible combobox that wraps long option labels on both
+ * closed and open states. Reads options from an underlying <select> and writes
+ * selections back to it so form submission is unchanged.
+ *
+ * Implements the ARIA 1.2 "combobox with listbox popup" pattern.
+ */
+
+class WrappingSelect extends HTMLElement {
+  constructor() {
+    super()
+
+    if (this.dataset.initialized === 'true') {
+      return
+    }
+
+    this.dataset.initialized = 'true'
+
+    this.selectEl = this.querySelector('select')
+
+    if (!this.selectEl) {
+      console.warn('wrapping-select: no <select> found inside wrapper', this)
+      return
+    }
+
+    this.buildCombobox()
+    this.attachEvents()
+  }
+
+  buildCombobox() {
+    const options = Array.from(this.selectEl.options)
+
+    if (options.length === 0) {
+      return
+    }
+
+    const selectId = this.selectEl.id
+    const labelledBy = this.selectEl.getAttribute('aria-labelledby')
+    const describedBy = this.selectEl.getAttribute('aria-describedby')
+    const labelEl = selectId ? document.querySelector(`label[for="${selectId}"]`) : null
+    const associatedLabelId = labelEl?.id ?? null
+
+    // Move the native select out of the tab order; keep it for form submission
+    // and as the no-JS fallback. Visually hidden via CSS once we add the class.
+    this.classList.add('wrapping-select--enhanced')
+    this.selectEl.setAttribute('tabindex', '-1')
+    this.selectEl.setAttribute('aria-hidden', 'true')
+
+    const selectedIndex = this.selectEl.selectedIndex >= 0 ? this.selectEl.selectedIndex : 0
+    const selectedOption = options[selectedIndex]
+
+    const toggle = document.createElement('button')
+    toggle.type = 'button'
+    toggle.id = `${selectId}-toggle`
+    toggle.className = 'wrapping-select__toggle'
+    toggle.setAttribute('aria-haspopup', 'listbox')
+    toggle.setAttribute('aria-expanded', 'false')
+
+    const labelIds = [associatedLabelId, labelledBy, toggle.id].filter(Boolean).join(' ')
+    if (labelIds) {
+      toggle.setAttribute('aria-labelledby', labelIds)
+    }
+
+    if (describedBy) {
+      toggle.setAttribute('aria-describedby', describedBy)
+    }
+
+    const toggleLabel = document.createElement('span')
+    toggleLabel.className = 'wrapping-select__toggle-label'
+    toggleLabel.textContent = selectedOption.text
+
+    const arrow = document.createElement('span')
+    arrow.className = 'wrapping-select__arrow'
+    arrow.setAttribute('aria-hidden', 'true')
+
+    toggle.append(toggleLabel, arrow)
+
+    const menu = document.createElement('ul')
+    menu.id = `${selectId}-menu`
+    menu.className = 'wrapping-select__menu'
+    menu.setAttribute('role', 'listbox')
+    menu.hidden = true
+
+    if (associatedLabelId) {
+      menu.setAttribute('aria-labelledby', associatedLabelId)
+    }
+
+    options.forEach((opt, idx) => {
+      const li = document.createElement('li')
+      li.id = `${selectId}-option-${idx}`
+      li.className = 'wrapping-select__option'
+      li.setAttribute('role', 'option')
+      li.dataset.value = opt.value
+      li.textContent = opt.text
+
+      if (idx === selectedIndex) {
+        li.setAttribute('aria-selected', 'true')
+      }
+
+      menu.appendChild(li)
+    })
+
+    this.toggle = toggle
+    this.toggleLabel = toggleLabel
+    this.menu = menu
+    this.appendChild(toggle)
+    this.appendChild(menu)
+  }
+
+  attachEvents() {
+    if (!this.toggle || !this.menu) {
+      return
+    }
+
+    this.toggle.addEventListener('click', () => this.toggleMenu())
+    this.toggle.addEventListener('keydown', e => this.handleToggleKeydown(e))
+    this.menu.addEventListener('click', e => this.handleMenuClick(e))
+    this.menu.addEventListener('mousemove', e => this.handleMenuHover(e))
+    this.menu.addEventListener('keydown', e => this.handleMenuKeydown(e))
+
+    document.addEventListener('click', e => {
+      if (!this.contains(e.target)) {
+        this.closeMenu()
+      }
+    })
+  }
+
+  toggleMenu() {
+    if (this.menu.hidden) {
+      this.openMenu()
+    } else {
+      this.closeMenu()
+    }
+  }
+
+  openMenu() {
+    this.menu.hidden = false
+    this.toggle.setAttribute('aria-expanded', 'true')
+
+    const current = this.menu.querySelector('[aria-selected="true"]') ?? this.menu.querySelector('[role="option"]')
+
+    if (current) {
+      this.setActive(current)
+    }
+
+    this.menu.setAttribute('tabindex', '-1')
+    this.menu.focus()
+  }
+
+  closeMenu() {
+    if (this.menu.hidden) {
+      return
+    }
+
+    this.menu.hidden = true
+    this.toggle.setAttribute('aria-expanded', 'false')
+    this.toggle.removeAttribute('aria-activedescendant')
+    this.clearActive()
+  }
+
+  selectOption(value) {
+    const opt = Array.from(this.menu.querySelectorAll('[role="option"]')).find(li => li.dataset.value === value)
+
+    if (!opt) {
+      return
+    }
+
+    this.menu.querySelectorAll('[role="option"]').forEach(o => o.removeAttribute('aria-selected'))
+    opt.setAttribute('aria-selected', 'true')
+
+    this.toggleLabel.textContent = opt.textContent
+    this.selectEl.value = value
+    this.selectEl.dispatchEvent(new Event('change', { bubbles: true }))
+
+    this.closeMenu()
+    this.toggle.focus()
+  }
+
+  setActive(li) {
+    this.clearActive()
+    li.classList.add('wrapping-select__option--active')
+    this.toggle.setAttribute('aria-activedescendant', li.id)
+    li.scrollIntoView({ block: 'nearest' })
+  }
+
+  clearActive() {
+    this.menu
+      .querySelectorAll('.wrapping-select__option--active')
+      .forEach(o => o.classList.remove('wrapping-select__option--active'))
+  }
+
+  handleToggleKeydown(e) {
+    if (['Enter', ' ', 'ArrowDown', 'ArrowUp'].includes(e.key)) {
+      e.preventDefault()
+      this.openMenu()
+    }
+  }
+
+  handleMenuClick(e) {
+    const li = e.target.closest('[role="option"]')
+
+    if (li) {
+      this.selectOption(li.dataset.value)
+    }
+  }
+
+  handleMenuHover(e) {
+    const li = e.target.closest('[role="option"]')
+
+    if (li) {
+      this.setActive(li)
+    }
+  }
+
+  handleMenuKeydown(e) {
+    const options = Array.from(this.menu.querySelectorAll('[role="option"]'))
+    const activeId = this.toggle.getAttribute('aria-activedescendant')
+    const activeIdx = options.findIndex(o => o.id === activeId)
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault()
+        this.setActive(options[Math.min(activeIdx + 1, options.length - 1)])
+        break
+      case 'ArrowUp':
+        e.preventDefault()
+        this.setActive(options[Math.max(activeIdx - 1, 0)])
+        break
+      case 'Home':
+        e.preventDefault()
+        this.setActive(options[0])
+        break
+      case 'End':
+        e.preventDefault()
+        this.setActive(options[options.length - 1])
+        break
+      case 'Enter':
+      case ' ':
+        e.preventDefault()
+        if (activeIdx >= 0) {
+          this.selectOption(options[activeIdx].dataset.value)
+        }
+        break
+      case 'Escape':
+        e.preventDefault()
+        this.closeMenu()
+        this.toggle.focus()
+        break
+      case 'Tab':
+        this.closeMenu()
+        break
+      default:
+        if (e.key.length === 1) {
+          this.typeAhead(e.key, options, activeIdx)
+        }
+    }
+  }
+
+  typeAhead(char, options, activeIdx) {
+    const lower = char.toLowerCase()
+
+    for (let step = 1; step <= options.length; step += 1) {
+      const idx = (activeIdx + step) % options.length
+
+      if (options[idx].textContent.trim().toLowerCase().startsWith(lower)) {
+        this.setActive(options[idx])
+        return
+      }
+    }
+  }
+}
+
+customElements.define('wrapping-select-wrapper', WrappingSelect)

--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
@@ -5,9 +5,8 @@
   position: relative;
   display: block;
 
-  // Once enhanced by JS, the native select is taken out of the visual flow
-  // (kept in the DOM for form submission). Without JS, the wrapper has no
-  // enhancement class and the select renders normally.
+  // When JavaScript is available, the native select is hidden and replaced
+  // with the custom dropdown. Without JavaScript, the native select shows as normal.
   &--enhanced {
     .govuk-select {
       position: absolute;
@@ -28,8 +27,6 @@
   @include govuk-font($size: 19);
   box-sizing: border-box;
   width: 100%;
-  // govuk-input/govuk-select set height: 2.5rem; use min-height so the toggle
-  // matches them at single-line and grows when the selected label wraps.
   min-height: 2.5rem;
   padding: 5px;
   background: govuk-colour('white');

--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
@@ -1,0 +1,116 @@
+// WrappingSelect: ARIA combobox with wrapping option labels.
+// The underlying native <select> stays for form submission and as the no-JS fallback.
+
+.wrapping-select {
+  position: relative;
+  display: block;
+
+  // Once enhanced by JS, the native select is taken out of the visual flow
+  // (kept in the DOM for form submission). Without JS, the wrapper has no
+  // enhancement class and the select renders normally.
+  &--enhanced {
+    .govuk-select {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      clip-path: inset(50%);
+      white-space: nowrap;
+      border: 0;
+    }
+  }
+}
+
+.wrapping-select__toggle {
+  @include govuk-font($size: 19);
+  box-sizing: border-box;
+  width: 100%;
+  // govuk-input/govuk-select set height: 2.5rem; use min-height so the toggle
+  // matches them at single-line and grows when the selected label wraps.
+  min-height: 2.5rem;
+  padding: 5px;
+  background: govuk-colour('white');
+  border: 2px solid $govuk-input-border-colour;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: flex-start;
+  gap: govuk-spacing(2);
+  color: $govuk-text-colour;
+  line-height: 1.25;
+
+  &:focus {
+    outline: $govuk-focus-width solid $govuk-focus-colour;
+    outline-offset: 0;
+    box-shadow: inset 0 0 0 $govuk-focus-width $govuk-input-border-colour;
+  }
+}
+
+.wrapping-select__toggle-label {
+  flex: 1 1 auto;
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+// Thin chevron imitating the native <select> arrow.
+.wrapping-select__arrow {
+  flex: 0 0 auto;
+  width: 5px;
+  height: 5px;
+  margin-top: 8px;
+  margin-right: 4px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+
+.wrapping-select__menu {
+  position: absolute;
+  z-index: 100;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  background: govuk-colour('white');
+  border: 2px solid $govuk-input-border-colour;
+  border-top: 0;
+  max-height: 320px;
+  overflow-y: auto;
+
+  &[hidden] {
+    display: none;
+  }
+
+  &:focus {
+    outline: 0;
+  }
+}
+
+.wrapping-select__option {
+  @include govuk-font($size: 19);
+  padding: govuk-spacing(1) govuk-spacing(2);
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+  cursor: pointer;
+
+  &--active {
+    background: govuk-colour('blue');
+    color: govuk-colour('white');
+  }
+
+  &[aria-selected='true']::before {
+    content: '✓';
+    font-size: 0.5em;
+    font-weight: 200;
+    margin-right: govuk-spacing(1);
+    vertical-align: middle;
+  }
+}

--- a/server/forms/sentence-plan/components/wrapping-select/wrappingSelect.ts
+++ b/server/forms/sentence-plan/components/wrapping-select/wrappingSelect.ts
@@ -15,9 +15,9 @@ import { buildNunjucksComponent } from '@ministryofjustice/hmpps-forge/express-n
  */
 export interface WrappingSelectProps {
   /**
-   * The select field to enhance. Must be a GovUKSelectInput. The rendered
-   * <select> stays in the DOM (visually hidden when JS enhances) and is what
-   * the form submits.
+   * The select field to wrap. Must be a GovUKSelectInput. The original dropdown
+   * stays on the page (hidden when JavaScript is available) so the form still
+   * submits the selected value in the normal way.
    */
   field: FieldBlockDefinition
 }

--- a/server/forms/sentence-plan/components/wrapping-select/wrappingSelect.ts
+++ b/server/forms/sentence-plan/components/wrapping-select/wrappingSelect.ts
@@ -1,0 +1,49 @@
+import { block as blockBuilder } from '@ministryofjustice/hmpps-forge/core/authoring'
+import { BlockDefinition, EvaluatedBlock, FieldBlockDefinition } from '@ministryofjustice/hmpps-forge/core/components'
+import { buildNunjucksComponent } from '@ministryofjustice/hmpps-forge/express-nunjucks'
+
+/**
+ * Props for the WrappingSelect component.
+ *
+ * Wraps a GovUKSelectInput with a custom ARIA combobox so long option labels can
+ * wrap onto multiple lines in both the closed and open states. The native <select>
+ * remains the source of truth for the form value (and is the no-JS fallback).
+ *
+ * The client-side enhancement reads options from the underlying <select>, builds
+ * a button + listbox combobox, and writes back to the select on selection so the
+ * form submits unchanged.
+ */
+export interface WrappingSelectProps {
+  /**
+   * The select field to enhance. Must be a GovUKSelectInput. The rendered
+   * <select> stays in the DOM (visually hidden when JS enhances) and is what
+   * the form submits.
+   */
+  field: FieldBlockDefinition
+}
+
+export interface WrappingSelect extends BlockDefinition, WrappingSelectProps {
+  variant: 'wrappingSelect'
+}
+
+export const wrappingSelect = buildNunjucksComponent<WrappingSelect>(
+  'wrappingSelect',
+  (block: EvaluatedBlock<WrappingSelect>): string => {
+    return `<wrapping-select-wrapper class="wrapping-select">\n${block.field.html}\n</wrapping-select-wrapper>`
+  },
+)
+
+/**
+ * Wraps a GovUKSelectInput with an accessible combobox where long option labels
+ * wrap onto multiple lines. Use for coded selects with long display labels.
+ *
+ * @example
+ * ```typescript
+ * WrappingSelect({
+ *   field: GovUKSelectInput({ code: 'actor', items: actorLabelOptions, ... }),
+ * })
+ * ```
+ */
+export function WrappingSelect(props: WrappingSelectProps): WrappingSelect {
+  return blockBuilder<WrappingSelect>({ ...props, variant: 'wrappingSelect' })
+}

--- a/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
@@ -19,7 +19,7 @@ import {
   GovUKGridRow,
   GovUKBody,
 } from '@ministryofjustice/hmpps-forge/govuk-components'
-import { AssessmentInfoDetails, ButtonAsLink } from '../../../../../components'
+import { AssessmentInfoDetails, ButtonAsLink, WrappingSelect } from '../../../../../components'
 import { actorLabelOptions, CaseData } from '../../../constants'
 import { canAccessSanContent } from '../../../guards'
 
@@ -124,21 +124,23 @@ export const stepRows = HtmlBlock({
           {
             width: 'one-sixth',
             blocks: [
-              GovUKSelectInput({
-                code: Format('step_actor_%1', Loop.Index0()),
-                label: {
-                  text: stepActorLabelText,
-                  classes: 'govuk-visually-hidden',
-                },
-                describedBy: stepActorHintId,
-                items: actorLabelOptions,
-                defaultValue: Item().path('actor'),
-                validWhen: [
-                  validation({
-                    condition: Self().match(Condition.IsRequired()),
-                    message: 'Select who will do the step',
-                  }),
-                ],
+              WrappingSelect({
+                field: GovUKSelectInput({
+                  code: Format('step_actor_%1', Loop.Index0()),
+                  label: {
+                    text: stepActorLabelText,
+                    classes: 'govuk-visually-hidden',
+                  },
+                  describedBy: stepActorHintId,
+                  items: actorLabelOptions,
+                  defaultValue: Item().path('actor'),
+                  validWhen: [
+                    validation({
+                      condition: Self().match(Condition.IsRequired()),
+                      message: 'Select who will do the step',
+                    }),
+                  ],
+                }),
               }),
             ],
           },

--- a/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
@@ -148,7 +148,7 @@ export const stepRows = HtmlBlock({
             width: 'one-half',
             blocks: [
               GovUKTextareaInput({
-                code: Format('step_description_%1', Item().index()),
+                code: Format('step_description_%1', Loop.Index0()),
                 label: {
                   text: stepDescriptionLabelText,
                   classes: 'govuk-visually-hidden',
@@ -165,27 +165,6 @@ export const stepRows = HtmlBlock({
                   validation({
                     condition: Self().match(Condition.IsRequired()),
                     message: 'Enter what they should do to achieve the goal',
-                  }),
-                ],
-              }),
-            ],
-          },
-          {
-            width: 'one-sixth',
-            blocks: [
-              GovUKSelectInput({
-                code: Format('step_status_%1', Loop.Index0()),
-                label: {
-                  text: stepStatusLabelText,
-                  classes: 'govuk-visually-hidden',
-                },
-                describedBy: stepStatusHintId,
-                items: stepStatusOptions,
-                defaultValue: Item().path('status'),
-                validWhen: [
-                  validation({
-                    condition: Self().match(Condition.IsRequired()),
-                    message: 'Select the status',
                   }),
                 ],
               }),

--- a/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
@@ -146,7 +146,7 @@ export const stepRows = HtmlBlock({
             width: 'one-half',
             blocks: [
               GovUKTextareaInput({
-                code: Format('step_description_%1', Loop.Index0()),
+                code: Format('step_description_%1', Item().index()),
                 label: {
                   text: stepDescriptionLabelText,
                   classes: 'govuk-visually-hidden',
@@ -163,6 +163,27 @@ export const stepRows = HtmlBlock({
                   validation({
                     condition: Self().match(Condition.IsRequired()),
                     message: 'Enter what they should do to achieve the goal',
+                  }),
+                ],
+              }),
+            ],
+          },
+          {
+            width: 'one-sixth',
+            blocks: [
+              GovUKSelectInput({
+                code: Format('step_status_%1', Loop.Index0()),
+                label: {
+                  text: stepStatusLabelText,
+                  classes: 'govuk-visually-hidden',
+                },
+                describedBy: stepStatusHintId,
+                items: stepStatusOptions,
+                defaultValue: Item().path('status'),
+                validWhen: [
+                  validation({
+                    condition: Self().match(Condition.IsRequired()),
+                    message: 'Select the status',
                   }),
                 ],
               }),


### PR DESCRIPTION
JIRA Ticket - [SP2-2237](https://dsdmoj.atlassian.net/browse/SP2-2237)

It seems there is not a way to make the built-in `<select>` widget allow for text wrapping. To get wrapping text, I had to replace the native control with a custom-built dropdown, styled to match the GOV.UK Design system. We can now control the rendering, but it means we lose the OS-native styling. 

Note: full keyboard support is implemented and whilst it does require JS, if JavaScript is disabled, the enhancement never runs and the native `<select>` renders as normal. The user loses text wrapping but the form still works.


[SP2-2237]: https://dsdmoj.atlassian.net/browse/SP2-2237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ