### PR TITLE
SP2-2280: Wrap status select dropdowns and centre toggle content

### DIFF
--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.scss
@@ -34,7 +34,7 @@
   text-align: left;
   cursor: pointer;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: govuk-spacing(2);
   color: $govuk-text-colour;
   line-height: 1.25;
@@ -58,7 +58,6 @@
   flex: 0 0 auto;
   width: 5px;
   height: 5px;
-  margin-top: 8px;
   margin-right: 4px;
   border-right: 2px solid currentColor;
   border-bottom: 2px solid currentColor;

--- a/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/add-steps/fields.ts
@@ -173,21 +173,23 @@ export const stepRows = HtmlBlock({
           {
             width: 'one-sixth',
             blocks: [
-              GovUKSelectInput({
-                code: Format('step_status_%1', Loop.Index0()),
-                label: {
-                  text: stepStatusLabelText,
-                  classes: 'govuk-visually-hidden',
-                },
-                describedBy: stepStatusHintId,
-                items: stepStatusOptions,
-                defaultValue: Item().path('status'),
-                validWhen: [
-                  validation({
-                    condition: Self().match(Condition.IsRequired()),
-                    message: 'Select the status',
-                  }),
-                ],
+              WrappingSelect({
+                field: GovUKSelectInput({
+                  code: Format('step_status_%1', Loop.Index0()),
+                  label: {
+                    text: stepStatusLabelText,
+                    classes: 'govuk-visually-hidden',
+                  },
+                  describedBy: stepStatusHintId,
+                  items: stepStatusOptions,
+                  defaultValue: Item().path('status'),
+                  validWhen: [
+                    validation({
+                      condition: Self().match(Condition.IsRequired()),
+                      message: 'Select the status',
+                    }),
+                  ],
+                }),
               }),
             ],
           },

--- a/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/update-goal-and-steps/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/goal-management/update-goal-and-steps/fields.ts
@@ -18,6 +18,7 @@ import {
   GovUKHeading,
   GovUKBody,
 } from '@ministryofjustice/hmpps-forge/govuk-components'
+import { WrappingSelect } from '../../../../../components'
 import { CaseData } from '../../../constants'
 
 const relatedAreasOfNeedText = Data('activeGoal.relatedAreasOfNeedLabels').pipe(
@@ -127,18 +128,20 @@ export const reviewStepsTable = TemplateWrapper({
               },
               slots: {
                 statusField: [
-                  GovUKSelectInput({
-                    code: Format('step_status_%1', Loop.Index0()),
-                    label: {
-                      text: 'Status',
-                      classes: 'govuk-visually-hidden',
-                    },
-                    classes: 'govuk-select--auto-width',
-                    formGroup: {
-                      classes: 'govuk-!-margin-bottom-0',
-                    },
-                    items: stepStatusOptions,
-                    defaultValue: Item().path('status'),
+                  WrappingSelect({
+                    field: GovUKSelectInput({
+                      code: Format('step_status_%1', Loop.Index0()),
+                      label: {
+                        text: 'Status',
+                        classes: 'govuk-visually-hidden',
+                      },
+                      classes: 'govuk-select--auto-width',
+                      formGroup: {
+                        classes: 'govuk-!-margin-bottom-0',
+                      },
+                      items: stepStatusOptions,
+                      defaultValue: Item().path('status'),
+                    }),
                   }),
                 ],
               },


### PR DESCRIPTION
- Apply WrappingSelect to step status dropdowns on Add Steps and Update Goal and Steps pages so long labels wrap.
- Centre toggle content vertically so single-line labels (status) and multi-line labels (actor) both look right.