### PR TITLE
SP2-2283: Number of steps completed - Content change 2

### DIFF
--- a/server/forms/sentence-plan/components/goal-summary-card/agreed.njk
+++ b/server/forms/sentence-plan/components/goal-summary-card/agreed.njk
@@ -84,7 +84,7 @@
       {#- Steps section (agreed - with counter and collapsible) -#}
       {% if params.stepsCount > 0 %}
         <p class="step-counter">
-          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed
+          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed.
         </p>
         <details class="govuk-details">
           <summary class="govuk-details__summary">

--- a/server/forms/sentence-plan/components/goal-summary-card/agreed.njk
+++ b/server/forms/sentence-plan/components/goal-summary-card/agreed.njk
@@ -84,7 +84,7 @@
       {#- Steps section (agreed - with counter and collapsible) -#}
       {% if params.stepsCount > 0 %}
         <p class="step-counter">
-          {{ params.completedCount }} out of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed.
+          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed
         </p>
         <details class="govuk-details">
           <summary class="govuk-details__summary">

--- a/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.test.ts
+++ b/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.test.ts
@@ -73,7 +73,7 @@ describe('goal summary card', () => {
     expect(html).toContain('Also relates to: employment and education; finances')
   })
 
-  it('uses "out of" wording for agreed card step counters', async () => {
+  it('uses "X of Y" wording for agreed card step counters', async () => {
     const html = await goalSummaryCardAgreed.render(
       {
         ...baseBlock,
@@ -86,7 +86,7 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 out of 2 steps completed.')
+    expect(html).toContain('1 of 2 steps completed')
   })
 
   it('uses "step completed" wording when there is one step on agreed cards', async () => {
@@ -99,7 +99,7 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 out of 1 step completed.')
+    expect(html).toContain('1 of 1 step completed')
   })
 
   it('uses "step completed" wording when there is one step on history cards', async () => {
@@ -112,6 +112,6 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 out of 1 step completed.')
+    expect(html).toContain('1 of 1 step completed')
   })
 })

--- a/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.test.ts
+++ b/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.test.ts
@@ -86,7 +86,7 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 of 2 steps completed')
+    expect(html).toContain('1 of 2 steps completed.')
   })
 
   it('uses "step completed" wording when there is one step on agreed cards', async () => {
@@ -99,7 +99,7 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 of 1 step completed')
+    expect(html).toContain('1 of 1 step completed.')
   })
 
   it('uses "step completed" wording when there is one step on history cards', async () => {
@@ -112,6 +112,6 @@ describe('goal summary card', () => {
       nunjucksEnv,
     )
 
-    expect(html).toContain('1 of 1 step completed')
+    expect(html).toContain('1 of 1 step completed.')
   })
 })

--- a/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.ts
+++ b/server/forms/sentence-plan/components/goal-summary-card/goalSummaryCard.ts
@@ -161,7 +161,7 @@ export interface GoalSummaryCardDraft extends BlockDefinition, GoalSummaryCardPr
  * Goal Summary Card (History) component interface.
  *
  * Read-only variant used inside the Plan History accordion. Steps are shown
- * inline (no collapsible wrapper), the step counter uses "X out of Y" wording,
+ * inline (no collapsible wrapper), the step counter uses "X of Y" wording,
  * and FUTURE-status goals display a "This is a future goal" line.
  */
 export interface GoalSummaryCardHistory extends BlockDefinition, GoalSummaryCardProps {
@@ -248,7 +248,7 @@ export const goalSummaryCardDraft = buildNunjucksComponent<GoalSummaryCardDraft>
 
 /**
  * Goal Summary Card (History) component.
- * Read-only variant for the Plan History accordion: inline steps and "X out of Y" counter.
+ * Read-only variant for the Plan History accordion: inline steps and "X of Y" counter.
  */
 export const goalSummaryCardHistory = buildNunjucksComponent<GoalSummaryCardHistory>(
   'goalSummaryCardHistory',
@@ -310,7 +310,7 @@ export function GoalSummaryCardDraft(props: GoalSummaryCardProps): GoalSummaryCa
 /**
  * Creates a Goal Summary Card for the Plan History accordion.
  *
- * Steps are shown inline and the counter reads "X out of Y steps completed".
+ * Steps are shown inline and the counter reads "X of Y steps completed".
  * For FUTURE-status goals the card includes a "This is a future goal" line.
  */
 export function GoalSummaryCardHistory(props: GoalSummaryCardProps): GoalSummaryCardHistory {

--- a/server/forms/sentence-plan/components/goal-summary-card/history.njk
+++ b/server/forms/sentence-plan/components/goal-summary-card/history.njk
@@ -3,7 +3,7 @@
 
   Variant used inside the Plan History accordion. Differs from agreed/draft:
   - Steps table is rendered inline (no <details> wrapper, no "View steps" toggle)
-  - Step counter wording is "X out of Y steps completed"
+  - Step counter wording is "X of Y steps completed"
   - Shows "This is a future goal" copy when goalStatus is FUTURE
 
   Params:
@@ -65,7 +65,7 @@
 
       {% if params.stepsCount > 0 %}
         <p class="step-counter">
-          {{ params.completedCount }} out of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed.
+          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed
         </p>
         <table class="govuk-table goal-summary-card__steps">
           <thead class="govuk-table__head">

--- a/server/forms/sentence-plan/components/goal-summary-card/history.njk
+++ b/server/forms/sentence-plan/components/goal-summary-card/history.njk
@@ -65,7 +65,7 @@
 
       {% if params.stepsCount > 0 %}
         <p class="step-counter">
-          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed
+          {{ params.completedCount }} of {{ params.stepsCount }} step{% if params.stepsCount != 1 %}s{% endif %} completed.
         </p>
         <table class="govuk-table goal-summary-card__steps">
           <thead class="govuk-table__head">


### PR DESCRIPTION
## Content change for step completed wording on goal summary card (`history` & `plan overview` pages):

- (Updated design): Keep full stop "X **of** Y step[s] completed."

BEFORE "X **out** of Y ...":
<img width="1024" height="367" alt="image" src="https://github.com/user-attachments/assets/50425e39-6084-46e3-8a6a-c69e76122a00" />

AFTER  "X **of** Y ...":
<img width="918" height="215" alt="Screenshot 2026-06-02 at 13 39 47" src="https://github.com/user-attachments/assets/7afb86a9-82e2-4475-b484-71d881ab494a" />
