### PR TITLE
Sp2 2280 long entry names status

### DIFF
--- a/integration_tests/pages/sentencePlan/addStepsPage.ts
+++ b/integration_tests/pages/sentencePlan/addStepsPage.ts
@@ -37,7 +37,7 @@ export default class AddStepsPage extends AbstractPage {
   }
 
   async getStepActorSelect(index: number): Promise<Locator> {
-    return this.page.locator(`#step_actor_${index}`)
+    return this.page.locator(`#step_actor_${index}-native`)
   }
 
   async getStepDescriptionInput(index: number): Promise<Locator> {
@@ -45,7 +45,7 @@ export default class AddStepsPage extends AbstractPage {
   }
 
   async getStepStatusSelect(index: number): Promise<Locator> {
-    return this.page.locator(`#step_status_${index}`)
+    return this.page.locator(`#step_status_${index}-native`)
   }
 
   async getRemoveStepButton(index: number): Promise<Locator> {
@@ -57,11 +57,11 @@ export default class AddStepsPage extends AbstractPage {
     const descriptionInput = await this.getStepDescriptionInput(index)
     const statusSelect = await this.getStepStatusSelect(index)
 
-    // The WrappingSelect combobox visually hides the underlying <select> on init.
-    // Tests can still set its value with force: true; form submission reads the select.
+    // WrappingSelect hides the native <select> visually (id suffixed with -native).
+    // Use force: true so Playwright can interact with the clipped element.
     await actorSelect.selectOption(actor, { force: true })
     await descriptionInput.fill(description)
-    await statusSelect.selectOption(status)
+    await statusSelect.selectOption(status, { force: true })
   }
 
   async clickAddStep(): Promise<void> {

--- a/integration_tests/specs/sentencePlan/createGoal.spec.ts
+++ b/integration_tests/specs/sentencePlan/createGoal.spec.ts
@@ -126,16 +126,16 @@ test.describe('Create Goal Journey', () => {
 
       const addStepsPage = await AddStepsPage.verifyOnPage(page)
       const firstStepRow = page.getByTestId('step-row').first()
-      const actorSelect = await addStepsPage.getStepActorSelect(0)
+      const actorToggle = page.locator('#step_actor_0')
       const descriptionInput = await addStepsPage.getStepDescriptionInput(0)
-      const statusSelect = page.locator('#step_status_0')
+      const statusToggle = page.locator('#step_status_0')
 
       await expect(descriptionInput).toHaveJSProperty('tagName', 'TEXTAREA')
 
       const [actorBox, descriptionBox, statusBox] = await Promise.all([
-        actorSelect.boundingBox(),
+        actorToggle.boundingBox(),
         descriptionInput.boundingBox(),
-        statusSelect.boundingBox(),
+        statusToggle.boundingBox(),
       ])
 
       expect(descriptionBox?.y).toBeCloseTo(actorBox?.y ?? 0, 0)

--- a/server/forms/sentence-plan/assets/form.scss
+++ b/server/forms/sentence-plan/assets/form.scss
@@ -29,7 +29,7 @@
   .step-row,
   .step-row-headers {
     display: grid;
-    grid-template-columns: 236px minmax(0, 1fr) 170px 55px;
+    grid-template-columns: 290px minmax(0, 1fr) 205px 74px;
     column-gap: govuk-spacing(3);
     margin-right: 0;
     margin-left: 0;

--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
@@ -116,7 +116,7 @@ class WrappingSelect extends HTMLElement {
 
     // Append into the surrounding .govuk-form-group when present so the red
     // error border (which only paints around form-group contents) extends down
-    // alongside the visible toggle, not just the label/error message.
+    // alongside the visible toggle, not just the error message.
     const formGroup = this.selectEl.closest('.govuk-form-group')
     const host = formGroup ?? this
     host.appendChild(toggle)

--- a/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
+++ b/server/forms/sentence-plan/components/wrapping-select/wrapping-select.mjs
@@ -38,6 +38,16 @@ class WrappingSelect extends HTMLElement {
     const labelledBy = this.selectEl.getAttribute('aria-labelledby')
     const describedBy = this.selectEl.getAttribute('aria-describedby')
     const labelEl = selectId ? document.querySelector(`label[for="${selectId}"]`) : null
+
+    // Hand the original id to the toggle so error summary links (which point at
+    // selectId) focus the visible control. The native select keeps a suffixed id
+    // for form submission and as the no-JS fallback.
+    if (selectId) {
+      this.selectEl.id = `${selectId}-native`
+      if (labelEl) {
+        labelEl.setAttribute('for', selectId)
+      }
+    }
     const associatedLabelId = labelEl?.id ?? null
 
     // Move the native select out of the tab order; keep it for form submission
@@ -51,7 +61,7 @@ class WrappingSelect extends HTMLElement {
 
     const toggle = document.createElement('button')
     toggle.type = 'button'
-    toggle.id = `${selectId}-toggle`
+    toggle.id = selectId || `${this.selectEl.name}-toggle`
     toggle.className = 'wrapping-select__toggle'
     toggle.setAttribute('aria-haspopup', 'listbox')
     toggle.setAttribute('aria-expanded', 'false')
@@ -103,8 +113,14 @@ class WrappingSelect extends HTMLElement {
     this.toggle = toggle
     this.toggleLabel = toggleLabel
     this.menu = menu
-    this.appendChild(toggle)
-    this.appendChild(menu)
+
+    // Append into the surrounding .govuk-form-group when present so the red
+    // error border (which only paints around form-group contents) extends down
+    // alongside the visible toggle, not just the label/error message.
+    const formGroup = this.selectEl.closest('.govuk-form-group')
+    const host = formGroup ?? this
+    host.appendChild(toggle)
+    host.appendChild(menu)
   }
 
   attachEvents() {


### PR DESCRIPTION
- Error summary links now focus the WrappingSelect dropdown (toggle takes the select's id so anchor links land on it).
 - Red error border now runs the full height alongside the dropdown (toggle is appended inside the form group instead of outside it).
- Step row column widths updated to match Figma (actor 290px, status 205px, Remove 74px) as per Figma design - see comments in JIRA ticker - [SP2-2280](https://dsdmoj.atlassian.net/browse/SP2-2280)


[SP2-2280]: https://dsdmoj.atlassian.net/browse/SP2-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ