### PR TITLE
Exclude POST body from RCE and SQLi ModSec rules to prevent false positives on practitioner free-text input

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -12,6 +12,11 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
+      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -12,6 +12,11 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
+      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,6 +12,11 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
+      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -12,6 +12,11 @@ generic-service:
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
       # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
+      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
+      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
+      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
 - Adds `SecRuleUpdateTargetById` exclusions for rules 932230, 932235, 932250 (RCE) and 942360 (SQLi) across all environments
  - These rules were producing false positives on legitimate practitioner text in free-text fields (e.g. goal titles, plan agreement notes,  phrases like "time in custody" were matching Unix command injection
  - Excluding `REQUEST_BODY` from these rules prevents the false positives while leaving URL parameter inspection intact, so real attacks via query strings are still caught
  - Dev and test are in `Enabled` mode so this unblocks those journeys; preprod and prod remain `DetectionOnly`

**Test Plan**

  - [ ] Deploy to dev
  - [ ] Submit a goal with title such as (similar to the false positives logged in Prod) `"I will spend my time in custody constructively"` and confirm it no longer returns a 406
  - [ ] Verify no new false positives appear in OpenSearch for dev after deploy
  - [ ] Confirm preprod/prod logs no longer show 932230/932235/932250/942360 hits on legitimate requests after promote
