### PR TITLE
Add authSource and userContext dimensions to App Insights telemetry events

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,5 @@
 import { HmppsUser } from '../../interfaces/hmppsUser'
+import { HandoverContext } from '../../interfaces/handover-api/response'
 
 export declare module 'express-session' {
   // Declare that the session will potentially contain these additional fields
@@ -17,6 +18,7 @@ export declare module 'express-session' {
     targetService?: string
     csrfToken?: string
     telemetryId?: string
+    handoverContext?: HandoverContext
   }
 }
 
@@ -55,6 +57,7 @@ declare global {
 
     interface Locals {
       user: HmppsUser
+      userContext?: string
       pageHistory?: string[]
       previousPageUrl?: string
       requestId?: string

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -35,6 +35,7 @@ declare global {
         name: string
         authSource: string
         token: string
+        userRoles: string[]
       }
     }
 

--- a/server/forms/sentence-plan/effects/goals/createGoal.ts
+++ b/server/forms/sentence-plan/effects/goals/createGoal.ts
@@ -10,6 +10,7 @@ import {
   buildGoalAnswers,
   getPractitionerName,
 } from './goalUtils'
+import { getUserContext } from '../telemetry/getUserContext'
 
 /**
  * Create a new goal
@@ -101,5 +102,7 @@ export const createGoal = (deps: SentencePlanEffectsDeps) => async (context: Sen
     relatedAreasCount: String(relatedAreas.length),
     targetDateOption: targetDateOption ?? '',
     targetDate: targetDate ?? '',
+    authSource: context.getState('user').authSource,
+    userContext: getUserContext(context),
   })
 }

--- a/server/forms/sentence-plan/effects/telemetry/getUserContext.ts
+++ b/server/forms/sentence-plan/effects/telemetry/getUserContext.ts
@@ -1,0 +1,19 @@
+import { SentencePlanContext } from '../types'
+
+/**
+ * Derives the best available user context for telemetry.
+ *
+ * For HMPPS_AUTH users (MPoP): resolves to the HMPPS Auth role e.g. PRISON or PROBATION.
+ * For OASYS users (handover): resolves to the subject's location e.g. PRISON or COMMUNITY,
+ * which is a substitute for practitioner type rather than an exact match.
+ */
+export const getUserContext = (context: SentencePlanContext): string => {
+  const user = context.getState('user')
+  const session = context.getSession()
+
+  if (user.authSource === 'HMPPS_AUTH') {
+    return user.userRoles?.[0] ?? 'UNKNOWN'
+  }
+
+  return session.handoverContext?.subject.location ?? 'UNKNOWN'
+}

--- a/server/forms/sentence-plan/effects/telemetry/sendTelemetryEvent.ts
+++ b/server/forms/sentence-plan/effects/telemetry/sendTelemetryEvent.ts
@@ -1,8 +1,11 @@
 import { telemetry } from '@ministryofjustice/hmpps-azure-telemetry'
 import { SentencePlanContext, SentencePlanEffectsDeps } from '../types'
+import { getUserContext } from './getUserContext'
 
 /**
- * Sends a telemetry event to App Insights, enriched with assessmentUuid and requestId.
+ * Sends a telemetry event to App Insights, enriched with assessmentUuid, requestId,
+ * authSource, and userContext (PRISON/PROBATION for HMPPS_AUTH users, PRISON/COMMUNITY
+ * for OASYS handover users based on subject location).
  *
  * @example
  * SentencePlanEffects.sendTelemetryEvent('SOME_EVENT')
@@ -12,5 +15,7 @@ export const sendTelemetryEvent =
     telemetry.trackEvent(eventName, {
       assessmentUuid: context.getData('assessmentUuid'),
       requestId: context.getState('requestId'),
+      authSource: context.getState('user').authSource,
+      userContext: getUserContext(context),
     })
   }

--- a/server/forms/sentence-plan/effects/types.ts
+++ b/server/forms/sentence-plan/effects/types.ts
@@ -414,7 +414,7 @@ export interface SentencePlanSession {
  * Request state via context.getState()
  */
 export interface SentencePlanState extends Record<string, unknown> {
-  user: User & { authSource: string; token: string }
+  user: User & { authSource: string; token: string; userRoles: string[] }
   requestId: string
 }
 

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -290,6 +290,7 @@ export default function setupAuthentication(options: AuthenticationOptions = {})
         name: hmppsUser.displayName ?? hmppsUser.username,
         authSource: hmppsUser.authSource,
         token: hmppsUser.token,
+        userRoles: hmppsUser.userRoles,
       },
     }
 

--- a/server/middleware/setUpCurrentUser.ts
+++ b/server/middleware/setUpCurrentUser.ts
@@ -24,13 +24,20 @@ export default function setUpCurrentUser() {
         authorities?: string[]
       }
 
+      const userRoles = roles.map(role => role.substring(role.indexOf('_') + 1))
+
       res.locals.user = {
         ...res.locals.user,
         userId,
         name,
         displayName: convertToTitleCase(name),
-        userRoles: roles.map(role => role.substring(role.indexOf('_') + 1)),
+        userRoles,
       }
+
+      res.locals.userContext =
+        res.locals.user.authSource === 'HMPPS_AUTH'
+          ? (userRoles[0] ?? 'UNKNOWN')
+          : (req.session.handoverContext?.subject.location ?? 'UNKNOWN')
 
       req.session.principal = {
         identifier: userId || res.locals.user.username,

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -16,6 +16,9 @@
     {% if user and user.authSource %}
       <meta name="ai-entry-point" content="{{ user.authSource }}">
     {% endif %}
+    {% if userContext %}
+      <meta name="ai-user-context" content="{{ userContext }}">
+    {% endif %}
     {% if data and data.assessment and data.assessment.flags %}
       <meta name="ai-user-type" content="{{ 'PRIVATE_BETA' if 'SAN_BETA' in data.assessment.flags else 'NATIONAL_ROLLOUT' }}">
     {% endif %}


### PR DESCRIPTION
We currently have no visibility of whether users are probation or prison practitioners. This data will allow us to start understanding the split and cross-check whether `PROBATION` and `COMMUNITY` reliably map to the same population across the two auth methods.

**Server-side changes**
- Adds `authSource` and `userContext` custom dimensions to all App Insights telemetry events fired from Sentence Plan effects
- For HMPPS_AUTH (MPoP) users, `userContext` resolves to the HMPPS Auth role e.g. `PRISON` or `PROBATION`, derived from the JWT `authorities` claim
- For OASYS (handover) users, `userContext` resolves to `subject.location` from the handover context e.g. `PRISON` or `COMMUNITY` - this is the subject's location rather than the practitioner's role, so is an approximation
- Extracts the logic into a shared `getUserContext` helper so both `sendTelemetryEvent` and `createGoal` use the same source of truth
- Also forwards `userRoles` from `HmppsUser` into `req.state.user` so it is accessible within effect context

**Client-side changes**
- Adds `userContext` to res.locals in setUpCurrentUser so it is available to templates on every request

**Limitations**
- Coverage of server-side events is submission-only, users who browse without submitting generate no events (the client-side meta tag addresses this for page views)
- For OASYS users, userContext reflects the subject's location rather than the practitioner's role, so it is not exact
- For OASYS users, userContext will show as UNKNOWN on the privacy screen (their first page load) as the handover context has not yet been loaded into session at that poin,  it is correct on all subsequent pages
- Historical data cannot be backfilled, these dimensions only appear from point of deployment

