### PR TITLE
SP2-2315: Plan History bug fix

### DIFF
--- a/server/forms/sentence-plan/effects/plan/derivePlanHistoryEntries.test.ts
+++ b/server/forms/sentence-plan/effects/plan/derivePlanHistoryEntries.test.ts
@@ -1001,7 +1001,7 @@ describe('derivePlanHistoryEntries', () => {
               statusDate: '2024-08-01T00:01:00.000Z',
               areaOfNeed: 'accommodation',
               relatedAreasOfNeed: [],
-              steps: [{ actor: 'person_on_probation', description: 'Find a flat', status: 'NOT_STARTED' }],
+              steps: [{ actor: 'person_on_probation', description: 'Find a flat', status: 'IN_PROGRESS' }],
             },
           },
         }),
@@ -1023,7 +1023,7 @@ describe('derivePlanHistoryEntries', () => {
       expect(entries[0]).toEqual(
         expect.objectContaining({
           type: 'goal_created',
-          steps: [{ actor: 'Joan', description: 'Find a flat', status: 'NOT_STARTED' }],
+          steps: [{ actor: 'Joan', description: 'Find a flat', status: 'IN_PROGRESS' }],
         }),
       )
     })

--- a/server/forms/sentence-plan/effects/steps/saveStepEditSession.test.ts
+++ b/server/forms/sentence-plan/effects/steps/saveStepEditSession.test.ts
@@ -373,4 +373,48 @@ describe('saveStepEditSession', () => {
       }),
     )
   })
+
+  it('should snapshot the submitted step status when saving steps for a newly-created goal', async () => {
+    // Plan-history folds this snapshot's steps into the "Goal created" entry,
+    // so a step created as IN_PROGRESS must not be snapshotted as NOT_STARTED.
+    // Arrange
+    const deps = createDeps()
+    const newStep = createStep({ id: 'step-new', actor: '', description: '', status: '' })
+    const session: SentencePlanSession = {
+      stepChanges: {
+        [activeGoal.uuid]: createStepChanges({
+          steps: [newStep],
+          toCreate: [newStep.id],
+        }),
+      },
+    }
+    const context = createMockContext({
+      session,
+      data: { navigationReferrer: 'add-goal' },
+      answers: {
+        step_actor_0: 'probation_practitioner',
+        step_description_0: 'Book an appointment',
+        step_status_0: 'IN_PROGRESS',
+      },
+    })
+
+    // Act
+    await saveStepEditSession(deps)(context)
+
+    // Assert
+    const commands = getExecutedCommands(deps)
+    expect(commands).toContainEqual(
+      expect.objectContaining({
+        timeline: expect.objectContaining({
+          type: 'GOAL_UPDATED',
+          data: expect.objectContaining({
+            isInitialStepAdd: true,
+            goalSnapshot: expect.objectContaining({
+              steps: [{ actor: 'probation_practitioner', description: 'Book an appointment', status: 'IN_PROGRESS' }],
+            }),
+          }),
+        }),
+      }),
+    )
+  })
 })

--- a/server/forms/sentence-plan/effects/steps/saveStepEditSession.ts
+++ b/server/forms/sentence-plan/effects/steps/saveStepEditSession.ts
@@ -150,18 +150,12 @@ export const saveStepEditSession = (deps: SentencePlanEffectsDeps) => async (con
   // `isInitialStepAdd: true` so plan-history folds it into GOAL_CREATED rather
   // than rendering a separate "Goal updated" entry.
   if (hasStepChanges && activeGoal?.uuid) {
-    // Existing steps keep their status (status edits live in updateGoalProgress);
-    // new steps default to NOT_STARTED.
-    const stepStatusByUuid = new Map<string, string>()
-    for (const original of activeGoal.steps ?? []) {
-      stepStatusByUuid.set(original.uuid, original.status)
-    }
     const postEditSteps = steps.map((step, index) => {
       const values = getFormValues(index)
       return {
         actor: values.actor,
         description: values.description,
-        status: stepStatusByUuid.get(step.id) ?? 'NOT_STARTED',
+        status: values.status,
       }
     })
 


### PR DESCRIPTION
When creating a new goal and adding steps with a status like "In Progress", the Plan History "Goal created" entry showed those steps as "Not Started".

The fix snapshots each step's submitted status (values.status) on the goal-created event, instead of looking it up from the goal's pre-existing steps — a lookup that always missed for brand-new steps and fell back to a NOT_STARTED default.