### PR TITLE
Pin ModSec ingress class and add rule exclusions for false positives

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -4,19 +4,24 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-dev.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
-      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
+      # Practitioner free-text in sentence-plan forms (goals, steps, notes) can false-block; skip those checks on these pages only.
+      SecRule REQUEST_URI "@beginsWith /sentence-plan/" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS"
+      # Random sign-in tokens (code/state) can false-block; skip those checks on the sign-in routes only.
+      SecRule REQUEST_URI "@beginsWith /sign-in/" "id:10020,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      SecRule REQUEST_URI "@beginsWith /oauth2/" "id:10021,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      # Random cookie values (analytics ai_*, login session) can false-block a user on every page; skip these cookies only.
+      SecRuleUpdateTargetByTag "attack-rce" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-lfi" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -4,19 +4,24 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-preprod.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
-      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
+      # Practitioner free-text in sentence-plan forms (goals, steps, notes) can false-block; skip those checks on these pages only.
+      SecRule REQUEST_URI "@beginsWith /sentence-plan/" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS"
+      # Random sign-in tokens (code/state) can false-block; skip those checks on the sign-in routes only.
+      SecRule REQUEST_URI "@beginsWith /sign-in/" "id:10020,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      SecRule REQUEST_URI "@beginsWith /oauth2/" "id:10021,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      # Random cookie values (analytics ai_*, login session) can false-block a user on every page; skip these cookies only.
+      SecRuleUpdateTargetByTag "attack-rce" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-lfi" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -4,19 +4,24 @@
 generic-service:
   ingress:
     host: arns-assessment-platform.hmpps.service.justice.gov.uk
+    className: modsec
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
       SecRuleEngine DetectionOnly
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
-      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
+      # Practitioner free-text in sentence-plan forms (goals, steps, notes) can false-block; skip those checks on these pages only.
+      SecRule REQUEST_URI "@beginsWith /sentence-plan/" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS"
+      # Random sign-in tokens (code/state) can false-block; skip those checks on the sign-in routes only.
+      SecRule REQUEST_URI "@beginsWith /sign-in/" "id:10020,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      SecRule REQUEST_URI "@beginsWith /oauth2/" "id:10021,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      # Random cookie values (analytics ai_*, login session) can false-block a user on every page; skip these cookies only.
+      SecRuleUpdateTargetByTag "attack-rce" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-lfi" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -4,19 +4,24 @@
 generic-service:
   ingress:
     host: arns-assessment-platform-test.hmpps.service.justice.gov.uk
+    className: modsec-non-prod
     modsecurity_enabled: true
     modsecurity_audit_enabled: true
     modsecurity_snippet: |
       SecRuleEngine On
       # Team here grants access to the OpenSearch logs to delve into the cause of the blockage
       SecDefaultAction "phase:2,pass,log,tag:github_team=hmpps-assessments,tag:namespace={{ .Release.Namespace }}"
-      # Disables request body scanning so free-text form fields (goal titles, step descriptions) do not trigger false positives
+      # Rule 920272 (unusual characters) false-alarms on normal post bodies; skip the raw body for this check only.
       SecRuleUpdateTargetById 920272 "!REQUEST_BODY"
-      # Excludes POST body from RCE and SQLi rules that produce false positives on legitimate practitioner free-text input
-      SecRuleUpdateTargetById 932230 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932235 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 932250 "!REQUEST_BODY"
-      SecRuleUpdateTargetById 942360 "!REQUEST_BODY"
+      # Practitioner free-text in sentence-plan forms (goals, steps, notes) can false-block; skip those checks on these pages only.
+      SecRule REQUEST_URI "@beginsWith /sentence-plan/" "id:10010,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-rce;ARGS,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS,ctl:ruleRemoveTargetByTag=attack-injection-generic;ARGS"
+      # Random sign-in tokens (code/state) can false-block; skip those checks on the sign-in routes only.
+      SecRule REQUEST_URI "@beginsWith /sign-in/" "id:10020,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      SecRule REQUEST_URI "@beginsWith /oauth2/" "id:10021,phase:1,pass,nolog,ctl:ruleRemoveTargetByTag=attack-sqli;ARGS,ctl:ruleRemoveTargetByTag=attack-rce;ARGS"
+      # Random cookie values (analytics ai_*, login session) can false-block a user on every page; skip these cookies only.
+      SecRuleUpdateTargetByTag "attack-rce" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-sqli" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
+      SecRuleUpdateTargetByTag "attack-lfi" "!REQUEST_COOKIES:/^(ai_(user|session)|hmpps-arns-assessment-platform-ui\.session)$/"
       # Change default denial to be a 406 so that we can tell easily that it is modsecurity doing the blocking
       SecRuleUpdateActionById 949110 "deny,status:406,logdata:%{SERVER_NAME}"
       SecRuleUpdateActionById 959100 "deny,status:406,logdata:%{SERVER_NAME}"


### PR DESCRIPTION
 Pin the ingress className explicitly (`modsec` in prod, `modsec-non-prod` elsewhere). 
 
- Removed four 932230/932235/932250/942360 "!REQUEST_BODY" lines - this was not having any effect since these rules inspect parsed fields as ARGS, not the raw body.
- /sentence-plan/ ARGS exclusion - switches off the RCE, SQLi, PHP and generic-injection families for form fields on these routes, where practitioner free-text coincidentally matches attack patterns; everything else stays scanned.
- /sign-in/ + /oauth2/ ARGS exclusion - switches off SQLi/RCE for the random OAuth code/state tokens on the auth routes.
- Three cookie exclusions - remove RCE/SQLi/LFI inspection from the App Insights and login-session cookies (random values that would otherwise false-block a user on every request).
