### PR TITLE
SP2-2313: Show Back to top link only when content exceeds viewport

### DIFF
--- a/assets/js/back-to-top.mjs
+++ b/assets/js/back-to-top.mjs
@@ -1,0 +1,36 @@
+/**
+ * Show "Back to top" links only when the page content exceeds the viewport
+ * height, so the link appears only when it is useful as an alternative to
+ * scrolling.
+ *
+ * Progressive enhancement: the link is visible by default in the markup, so
+ * without JS it still works. This module hides it when the page is not
+ * scrollable, and re-evaluates on resize and when content height changes.
+ *
+ * Opt in by adding the `js-back-to-top` class to the link's wrapper element.
+ */
+export function initBackToTop() {
+  const links = document.querySelectorAll('.js-back-to-top')
+
+  if (links.length === 0) {
+    return
+  }
+
+  const update = () => {
+    const isScrollable = document.documentElement.scrollHeight > window.innerHeight
+
+    links.forEach(link => {
+      link.hidden = !isScrollable
+    })
+  }
+
+  update()
+
+  window.addEventListener('resize', update)
+
+  // Content height can change after load (fonts, images, expanding sections),
+  // so re-check whenever the body resizes.
+  if ('ResizeObserver' in window) {
+    new ResizeObserver(update).observe(document.body)
+  }
+}

--- a/assets/js/back-to-top.mjs
+++ b/assets/js/back-to-top.mjs
@@ -26,6 +26,19 @@ export function initBackToTop() {
 
   update()
 
+  // Activating the link scrolls to the top; also move keyboard focus there so a
+  // keyboard or screen-reader user continues from the top rather than from the
+  // link they just left (a plain href="#" only scrolls, it does not move focus).
+  links.forEach(link => {
+    const anchor = link.querySelector('a')
+
+    anchor?.addEventListener('click', event => {
+      event.preventDefault()
+      window.scrollTo({ top: 0 })
+      moveFocusToTop()
+    })
+  })
+
   window.addEventListener('resize', update)
 
   // Content height can change after load (fonts, images, expanding sections),
@@ -33,4 +46,18 @@ export function initBackToTop() {
   if ('ResizeObserver' in window) {
     new ResizeObserver(update).observe(document.body)
   }
+}
+
+/**
+ * Move keyboard focus to the top of the page without scrolling away from it.
+ * Targets the main landmark (the skip-link destination), falling back to the
+ * page heading or body. `preventScroll` keeps the viewport at the top, and the
+ * temporary tabindex is removed on blur so it does not become a lingering tab stop.
+ */
+function moveFocusToTop() {
+  const target = document.getElementById('main-content') ?? document.querySelector('h1') ?? document.body
+
+  target.setAttribute('tabindex', '-1')
+  target.focus({ preventScroll: true })
+  target.addEventListener('blur', () => target.removeAttribute('tabindex'), { once: true })
 }

--- a/assets/js/back-to-top.mjs
+++ b/assets/js/back-to-top.mjs
@@ -26,9 +26,8 @@ export function initBackToTop() {
 
   update()
 
-  // Activating the link scrolls to the top; also move keyboard focus there so a
-  // keyboard or screen-reader user continues from the top rather than from the
-  // link they just left (a plain href="#" only scrolls, it does not move focus).
+  // Scroll to the top and move focus there too, so keyboard/screen-reader users
+  // continue from the top (href="#" only scrolls, it doesn't move focus).
   links.forEach(link => {
     const anchor = link.querySelector('a')
 
@@ -49,10 +48,10 @@ export function initBackToTop() {
 }
 
 /**
- * Move keyboard focus to the top of the page without scrolling away from it.
- * Targets the main landmark (the skip-link destination), falling back to the
- * page heading or body. `preventScroll` keeps the viewport at the top, and the
- * temporary tabindex is removed on blur so it does not become a lingering tab stop.
+ * Move the keyboard to the top so the next Tab continues from there, not the
+ * clicked link. Focuses the main content area (or heading/body as a fallback).
+ * preventScroll keeps the page at the top; the temporary tabindex is removed
+ * afterwards so it isn't left as a stray Tab stop.
  */
 function moveFocusToTop() {
   const target = document.getElementById('main-content') ?? document.querySelector('h1') ?? document.body

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -4,6 +4,7 @@ import * as mojFrontend from '@ministryofjustice/frontend'
 import { CollapsibleNav } from './collapsible-nav.mjs'
 import { SupportWidget } from './support-widget.mjs'
 import { initScrollRestore } from './scroll-restore.mjs'
+import { initBackToTop } from './back-to-top.mjs'
 import { CopyCode } from './copy-code.mjs'
 import { SessionTimeoutModal } from './session-timeout-modal.mjs'
 import { ArnsCommonHeader } from './arns-common-header.mjs'
@@ -13,6 +14,7 @@ import '../../server/forms/sentence-plan/components/report-problem-link/report-p
 govukFrontend.initAll()
 mojFrontend.initAll()
 initScrollRestore()
+initBackToTop()
 
 customElements.define('app-copy-code', CopyCode)
 customElements.define('app-support-widget', SupportWidget)

--- a/integration_tests/specs/sentencePlan/components/backToTop.spec.ts
+++ b/integration_tests/specs/sentencePlan/components/backToTop.spec.ts
@@ -34,8 +34,9 @@ test.describe('Back to top link', () => {
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
     await page.locator(backToTopLink).click()
 
-    // Assert
+    // Assert - scrolled to the top and keyboard focus moved there too
     await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+    await expect(page.locator('#main-content')).toBeFocused()
   })
 
   test('is not rendered on the privacy screen', async ({ page, createSession }) => {

--- a/integration_tests/specs/sentencePlan/components/backToTop.spec.ts
+++ b/integration_tests/specs/sentencePlan/components/backToTop.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from '@playwright/test'
+import { test, TargetService } from '../../../support/fixtures'
+import PlanOverviewPage from '../../../pages/sentencePlan/planOverviewPage'
+import { navigateToSentencePlan, navigateToPrivacyScreen } from '../sentencePlanUtils'
+
+const backToTopWrapper = '.js-back-to-top'
+const backToTopLink = '[data-ai-id="back-to-top"]'
+
+test.describe('Back to top link', () => {
+  test('is hidden when the page content fits within the viewport', async ({ page, createSession }) => {
+    // Arrange - a blank plan overview is short content, and a tall viewport leaves nothing to scroll.
+    await page.setViewportSize({ width: 1280, height: 3000 })
+    const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+
+    // Act
+    await navigateToSentencePlan(page, handoverLink)
+    await PlanOverviewPage.verifyOnPage(page)
+
+    // Assert
+    await expect(page.locator(backToTopWrapper)).toBeHidden()
+  })
+
+  test('is visible and returns to the top when content exceeds the viewport', async ({ page, createSession }) => {
+    // Arrange - a short viewport forces the page to scroll.
+    await page.setViewportSize({ width: 1280, height: 400 })
+    const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+
+    // Act
+    await navigateToSentencePlan(page, handoverLink)
+    await PlanOverviewPage.verifyOnPage(page)
+    await expect(page.locator(backToTopWrapper)).toBeVisible()
+
+    await page.mouse.wheel(0, 1000)
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBeGreaterThan(0)
+    await page.locator(backToTopLink).click()
+
+    // Assert
+    await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0)
+  })
+
+  test('is not rendered on the privacy screen', async ({ page, createSession }) => {
+    // Arrange - a short viewport would show the link if it were present.
+    await page.setViewportSize({ width: 1280, height: 400 })
+    const { handoverLink } = await createSession({ targetService: TargetService.SENTENCE_PLAN })
+
+    // Act
+    await navigateToPrivacyScreen(page, handoverLink)
+
+    // Assert
+    await expect(page.locator(backToTopWrapper)).toHaveCount(0)
+  })
+})

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/fields.ts
@@ -205,7 +205,3 @@ export const agreementHistory = GovUKAccordion({
     }),
   ),
 })
-
-export const backToTopLink = GovUKBody({
-  text: '<a href="#" class="govuk-link govuk-!-display-none-print">↑ Back to top</a>',
-})

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/step.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/plan-history/step.ts
@@ -1,5 +1,5 @@
 import { access, step } from '@ministryofjustice/hmpps-forge/core/authoring'
-import { subtitleText, agreementHistory, backToTopLink } from './fields'
+import { subtitleText, agreementHistory } from './fields'
 import { AuditEvent, SentencePlanEffects } from '../../../../../../effects'
 import { isOasysAccess, redirectIfNotPostAgreement, redirectToPrivacyUnlessAccepted } from '../../../../guards'
 
@@ -15,7 +15,7 @@ export const planHistoryStep = step({
       },
     },
   },
-  blocks: [subtitleText, agreementHistory, backToTopLink],
+  blocks: [subtitleText, agreementHistory],
   onAccess: [
     redirectToPrivacyUnlessAccepted(),
     access({

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/previous-versions/fields.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/previous-versions/fields.ts
@@ -1,5 +1,4 @@
 import { Data } from '@ministryofjustice/hmpps-forge/core/authoring'
-import { GovUKBody } from '@ministryofjustice/hmpps-forge/govuk-components'
 import { PreviousVersions } from '../../../../../../components/previous-versions/previousVersions'
 import { CaseData } from '../../../../constants'
 
@@ -7,8 +6,4 @@ export const previousVersions = PreviousVersions({
   personName: CaseData.Forename,
   previousVersions: Data('previousVersions'),
   showAssessmentColumn: Data('showAssessmentColumn'),
-})
-
-export const backToTopLink = GovUKBody({
-  text: '<a href="#" class="govuk-link">↑ Back to top</a>',
 })

--- a/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/previous-versions/step.ts
+++ b/server/forms/sentence-plan/versions/v1.0/journeys/plan-overview/steps/previous-versions/step.ts
@@ -1,7 +1,7 @@
 import { access, step } from '@ministryofjustice/hmpps-forge/core/authoring'
 import { isOasysAccess, redirectToPrivacyUnlessAccepted } from '../../../../guards'
 import { AuditEvent, SentencePlanEffects } from '../../../../../../effects'
-import { backToTopLink, previousVersions } from './fields'
+import { previousVersions } from './fields'
 
 export const previousVersionsStep = step({
   path: '/previous-versions',
@@ -16,7 +16,7 @@ export const previousVersionsStep = step({
     },
   },
   reachability: { entryWhen: true },
-  blocks: [previousVersions, backToTopLink],
+  blocks: [previousVersions],
   onAccess: [
     redirectToPrivacyUnlessAccepted(),
     access({

--- a/server/forms/sentence-plan/views/sentence-plan-step.njk
+++ b/server/forms/sentence-plan/views/sentence-plan-step.njk
@@ -104,6 +104,13 @@
                 {% for block in blocks %}
                   {{ block | safe if loop.index0 != sidebarIndex }}
                 {% endfor %}
+
+                {# Visible by default so it works without JS; back-to-top.mjs hides it when the page fits the viewport (SP2-2313). #}
+                {% if not hideBackToTop %}
+                  <p class="govuk-body js-back-to-top govuk-!-display-none-print">
+                    <a href="#" class="govuk-link" data-ai-id="back-to-top">↑ Back to top</a>
+                  </p>
+                {% endif %}
               </div>
             </div>
           </div>
@@ -116,6 +123,13 @@
           {% for block in blocks %}
             {{ block | safe }}
           {% endfor %}
+
+          {# Visible by default so it works without JS; back-to-top.mjs hides it when the page fits the viewport #}
+          {% if not hideBackToTop %}
+            <p class="govuk-body js-back-to-top govuk-!-display-none-print">
+              <a href="#" class="govuk-link" data-ai-id="back-to-top">↑ Back to top</a>
+            </p>
+          {% endif %}
         {% endif %}
       </form>
     </div>

--- a/server/forms/shared/privacy-screen/createPrivacyScreen.ts
+++ b/server/forms/shared/privacy-screen/createPrivacyScreen.ts
@@ -111,6 +111,7 @@ export function createPrivacyScreen(config: PrivacyScreenConfig) {
         basePath,
         hideNavigation: true,
         hidePreviousVersions: true,
+        hideBackToTop: true,
         hmppsHeaderServiceNameLink: headerServiceNameLink,
         backlink: when(Data('accessDetails.accessType').match(Condition.Equals('OASYS')))
           .then(Data('accessDetails.oasysRedirectUrl'))


### PR DESCRIPTION
Adds a "Back to top" link to every sentence plan page, shown only when the page is long enough to need scrolling.
  
 - New back-to-top.mjs hides the link when the whole page already fits on screen, and shows it when the page can be scrolled. It re-checks when the window is resized or the page content grows (via ResizeObserver). Without JavaScript the link just stays visible, so it still works either way.
- The link is added once in the shared page template (sentence-plan-step.njk), inside the main content column, so on two-column pages (like Create Goal) it sits under the buttons rather than under the side menu.
- When the link is clicked, the page scrolls to the top and keyboard focus moves there too, so keyboard and screen-reader users carry on from the top of the page instead of from the link they just clicked.
- Removed the old duplicate link definitions from the Plan history and Previous versions pages, since the shared template now covers them.
- Added data-ai-id="back-to-top" so clicks are recorded in App Insights Click Analytics (AC2).
- The link is hidden on the privacy screen via a hideBackToTop flag.

