### PR TITLE
Fix stale step status add steps

### DIFF
--- a/server/forms/sentence-plan/effects/steps/initializeStepEditSession.test.ts
+++ b/server/forms/sentence-plan/effects/steps/initializeStepEditSession.test.ts
@@ -1,0 +1,233 @@
+import { initializeStepEditSession } from './initializeStepEditSession'
+import type { SentencePlanContext, SentencePlanSession, StepChanges, StepSession } from '../types'
+
+interface MockContextOptions {
+  session?: Partial<SentencePlanSession> | undefined
+  activeGoalUuid?: string | undefined
+  activeGoal?: { stepsCollectionUuid?: string } | undefined
+  stepsOriginal?: StepSession[] | undefined
+}
+
+function createMockContext(options: MockContextOptions = {}) {
+  const session = options.session
+  const answers: Record<string, string> = {}
+
+  return {
+    getSession: jest.fn(() => session),
+    getData: jest.fn((key: string) => {
+      if (key === 'activeGoalUuid') {
+        return options.activeGoalUuid
+      }
+
+      if (key === 'activeGoal') {
+        return options.activeGoal
+      }
+
+      if (key === 'activeGoalStepsOriginal') {
+        return options.stepsOriginal
+      }
+
+      return undefined
+    }),
+    setData: jest.fn(),
+    getAnswer: jest.fn((key: string) => answers[key]),
+    setAnswer: jest.fn((key: string, value: string) => {
+      answers[key] = value
+    }),
+  } as unknown as SentencePlanContext
+}
+
+function createStepChanges(overrides: Partial<StepChanges> = {}): StepChanges {
+  return {
+    steps: [],
+    toCreate: [],
+    toUpdate: [],
+    toDelete: [],
+    ...overrides,
+  }
+}
+
+function createStep(overrides: Partial<StepSession> = {}): StepSession {
+  return {
+    id: 'step-id',
+    actor: '',
+    description: '',
+    status: '',
+    ...overrides,
+  }
+}
+
+describe('initializeStepEditSession', () => {
+  describe('early returns', () => {
+    it('should return early when activeGoalUuid is undefined', async () => {
+      // Arrange
+      const context = createMockContext({ session: {}, activeGoalUuid: undefined })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(context.setData).not.toHaveBeenCalled()
+    })
+
+    it('should return early when session is undefined', async () => {
+      // Arrange
+      const context = createMockContext({ session: undefined, activeGoalUuid: 'goal-1' })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(context.setData).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('first visit seeding', () => {
+    it('should seed the session from the API steps when no entry exists', async () => {
+      // Arrange
+      const session: Partial<SentencePlanSession> = {}
+      const stepsOriginal = [
+        createStep({ id: 'existing-1', actor: 'PP', description: 'Do thing', status: 'IN_PROGRESS' }),
+      ]
+      const context = createMockContext({
+        session,
+        activeGoalUuid: 'goal-1',
+        activeGoal: { stepsCollectionUuid: 'collection-1' },
+        stepsOriginal,
+      })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(session.stepChanges!['goal-1']).toEqual({
+        steps: stepsOriginal,
+        toCreate: [],
+        toUpdate: [],
+        toDelete: [],
+        collectionUuid: 'collection-1',
+      })
+    })
+
+    it('should seed a single empty step when the goal has no API steps', async () => {
+      // Arrange
+      const session: Partial<SentencePlanSession> = {}
+      const context = createMockContext({
+        session,
+        activeGoalUuid: 'goal-1',
+        stepsOriginal: [],
+      })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(session.stepChanges!['goal-1']).toEqual({
+        steps: [{ id: 'step_0', actor: '', description: '', status: '' }],
+        toCreate: ['step_0'],
+        toUpdate: [],
+        toDelete: [],
+      })
+    })
+  })
+
+  describe('reconciling a reused session', () => {
+    it('should refresh an existing step status from the latest API value', async () => {
+      // Arrange
+      // Session holds a stale status; the API now has the updated value.
+      const session: Partial<SentencePlanSession> = {
+        stepChanges: {
+          'goal-1': createStepChanges({
+            steps: [createStep({ id: 'existing-1', actor: 'PP', description: 'Find housing', status: 'IN_PROGRESS' })],
+          }),
+        },
+      }
+      const stepsOriginal = [
+        createStep({ id: 'existing-1', actor: 'PP', description: 'Find housing', status: 'CANNOT_BE_DONE_YET' }),
+      ]
+      const context = createMockContext({ session, activeGoalUuid: 'goal-1', stepsOriginal })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(session.stepChanges!['goal-1'].steps[0].status).toBe('CANNOT_BE_DONE_YET')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_status_0', 'CANNOT_BE_DONE_YET')
+    })
+
+    it('should preserve in-progress new rows tracked in toCreate', async () => {
+      // Arrange
+      const newStep = createStep({ id: 'new-1', actor: 'Person', description: 'Half typed', status: '' })
+      const session: Partial<SentencePlanSession> = {
+        stepChanges: {
+          'goal-1': createStepChanges({
+            steps: [createStep({ id: 'existing-1', status: 'IN_PROGRESS' }), newStep],
+            toCreate: ['new-1'],
+          }),
+        },
+      }
+      const stepsOriginal = [createStep({ id: 'existing-1', status: 'COMPLETED' })]
+      const context = createMockContext({ session, activeGoalUuid: 'goal-1', stepsOriginal })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      const { steps } = session.stepChanges!['goal-1']
+      expect(steps).toHaveLength(2)
+      expect(steps[0].status).toBe('COMPLETED') // existing row refreshed from API
+      expect(steps[1]).toEqual(newStep) // new row untouched
+    })
+
+    it('should preserve row order when reconciling', async () => {
+      // Arrange
+      const session: Partial<SentencePlanSession> = {
+        stepChanges: {
+          'goal-1': createStepChanges({
+            steps: [createStep({ id: 'b' }), createStep({ id: 'a' })],
+          }),
+        },
+      }
+      const stepsOriginal = [
+        createStep({ id: 'a', status: 'NOT_STARTED' }),
+        createStep({ id: 'b', status: 'COMPLETED' }),
+      ]
+      const context = createMockContext({ session, activeGoalUuid: 'goal-1', stepsOriginal })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      // Session ordering (b, a) is kept; only values are refreshed from the API.
+      const { steps } = session.stepChanges!['goal-1']
+      expect(steps.map(step => step.id)).toEqual(['b', 'a'])
+      expect(steps[0].status).toBe('COMPLETED')
+      expect(steps[1].status).toBe('NOT_STARTED')
+    })
+
+  })
+
+  describe('answer restoration', () => {
+    it('should restore actor, description and status answers for each step', async () => {
+      // Arrange
+      const session: Partial<SentencePlanSession> = {}
+      const stepsOriginal = [
+        createStep({ id: 'existing-1', actor: 'PP', description: 'First', status: 'IN_PROGRESS' }),
+        createStep({ id: 'existing-2', actor: 'Person', description: 'Second', status: 'COMPLETED' }),
+      ]
+      const context = createMockContext({ session, activeGoalUuid: 'goal-1', stepsOriginal })
+
+      // Act
+      await initializeStepEditSession()(context)
+
+      // Assert
+      expect(context.setData).toHaveBeenCalledWith('activeGoalStepsEdited', stepsOriginal)
+      expect(context.setAnswer).toHaveBeenCalledWith('step_actor_0', 'PP')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_description_0', 'First')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_status_0', 'IN_PROGRESS')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_actor_1', 'Person')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_description_1', 'Second')
+      expect(context.setAnswer).toHaveBeenCalledWith('step_status_1', 'COMPLETED')
+    })
+  })
+})

--- a/server/forms/sentence-plan/effects/steps/initializeStepEditSession.ts
+++ b/server/forms/sentence-plan/effects/steps/initializeStepEditSession.ts
@@ -1,4 +1,4 @@
-import { SentencePlanContext, StepChangesStorage } from '../types'
+import { SentencePlanContext, StepChangesStorage, StepSession } from '../types'
 
 /**
  * Initialize the step edit session
@@ -6,6 +6,10 @@ import { SentencePlanContext, StepChangesStorage } from '../types'
  * Sets up the step changes in session for the dynamic form, keyed by goal UUID.
  * If the goal has existing steps from the API, those are loaded into session.
  * Otherwise, starts with one empty step for new goals.
+ *
+ * Saved steps are then updated with the latest values from the API, so a change
+ * made on another page (e.g. a status set on "Update goal and steps") isn't shown
+ * stale here. Unsaved new rows are left as they are.
  *
  * Restores field answers from session so saved values display on GET requests.
  */
@@ -45,7 +49,17 @@ export const initializeStepEditSession = () => async (context: SentencePlanConte
     }
   }
 
-  const { steps } = storage[activeGoalUuid]
+  const changes = storage[activeGoalUuid]
+
+  // Update saved steps with the latest API values so changes made elsewhere
+  // aren't shown stale. Unsaved new rows (toCreate) keep what the user typed.
+  const newStepIds = new Set(changes.toCreate)
+  const stepsById = new Map<string, StepSession>(
+    (context.getData('activeGoalStepsOriginal') ?? []).map(step => [step.id, step]),
+  )
+  changes.steps = changes.steps.map(step => (newStepIds.has(step.id) ? step : (stepsById.get(step.id) ?? step)))
+
+  const { steps } = changes
   context.setData('activeGoalStepsEdited', steps)
 
   // Restore field answers from session (GET requests only)


### PR DESCRIPTION
### Bug Fix

The Add steps page was showing the wrong step status. If you changed a step's status somewhere else, (for example, on Update goal and steps) and then opened Add steps, it still showed the old status, even though the database had saved the new one correctly.

**Steps to reproduce**  

  1. Create a goal and agree the plan
  2. On the Plan Overview, click Update on the goal card
  3. Change a step's status (e.g. 'In progress' → 'Cannot be done yet') and save
  4. Go back into the goal and click Add or change steps
  5. The status still shows as 'In progress'
  
**Why it happened**

The Add steps page keeps a temporary copy of the steps in the session, and that copy was only refreshed when you saved from that page. Changing a status on another page updated the database but left the old copy behind, so the page kept showing stale data.

This only surfaced if you'd previously left Add steps without a clean save e.g. an unfinished step or which leaves that copy lying around.

**The fix**   

When the Add steps page loads, saved steps are now refreshed with the latest values from the database, so changes made elsewhere show correctly. Steps you're still adding (unsaved) are left untouched, so half-finished rows aren't wiped when you click Add another step / Remove.